### PR TITLE
Update SelectItem.tsx

### DIFF
--- a/packages/select/src/SelectItem.tsx
+++ b/packages/select/src/SelectItem.tsx
@@ -8,7 +8,7 @@ export const SelectItem = (StyledSelectItem: any) =>
       isDisabled,
       label,
       value,
-    }: any) => {
+    }: any, ref: any) => {
       if (Platform.OS !== 'web') {
         return (
           <StyledSelectItem>


### PR DESCRIPTION
fixing "forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?"