### PR TITLE
Update SelectIcon.tsx

### DIFF
--- a/packages/select/src/SelectIcon.tsx
+++ b/packages/select/src/SelectIcon.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react';
 import { SelectContext } from './SelectContext';
 
 export const SelectIcon = (StyledSelectIcon: any) =>
-  forwardRef(({ children, ...props }: any) => {
+  forwardRef(({ children, ...props }: any, ref: any) => {
     const {
       isHovered,
       isFocused,


### PR DESCRIPTION
fixing "forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?"