### PR TITLE
Fix text from documentation

### DIFF
--- a/example/storybook/src/guides/building-desing-system/index.stories.mdx
+++ b/example/storybook/src/guides/building-desing-system/index.stories.mdx
@@ -16,7 +16,7 @@ This enables you to build your own collection of components that match your visi
 
 ## Step 1: Create Your Own Package
 
-If you are planning to build your own design system, you can direclty **fork** [`@gluestack-ui/themed`](https://https://github.com/gluestack/gluestack-ui) – a meticulously organized monorepo and begin shaping your design system upon this solid foundation.
+If you are planning to build your own design system, you can direclty **fork** [`@gluestack-ui/themed`](https://github.com/gluestack/gluestack-ui) – a meticulously organized monorepo and begin shaping your design system upon this solid foundation.
 
 - This includes a component library package `@gluestack-ui/themed` in `packages/themed`
 - This includes a storybook in `example/storybook` for both React and React Native.
@@ -26,7 +26,7 @@ Follow these steps after **forking** this repository:
 ### Change library name
 
 - Navigate to the `packages/themed` and open `package.json`. (You can rename the folder if you need)
-- Locate the `name` field in th `package.json` file and update it to `@myapp/components`
+- Locate the `name` field in the `package.json` file and update it to `@myapp/components`
 
   ```json
   //package.json


### PR DESCRIPTION
 Fix some text from Guides > Building Design System page:
 - Fix the link for the github repository;
 - Fix the word 'th' to 'the'