### PR TITLE
fix: typo in ButtonGroup props documentation

### DIFF
--- a/example/storybook/src/components/Forms/Button/index.stories.mdx
+++ b/example/storybook/src/components/Forms/Button/index.stories.mdx
@@ -248,7 +248,7 @@ Contains all group related layout style props and actions. It inherits all the p
           </Table.TD>
           <Table.TD>
             <Table.TText>
-              Set the direction of Button group to vertical or horizantal
+              Set the direction of Button group to vertical or horizontal
             </Table.TText>
           </Table.TD>
         </Table.TR>


### PR DESCRIPTION
## Description

Fix a small typo in ButtonGroup's props documentation (https://ui.gluestack.io/docs/components/forms/button)