### PR TITLE
docs: use `npx expo install` for dependency management

### DIFF
--- a/example/storybook/src/guides/install-expo/index.stories.mdx
+++ b/example/storybook/src/guides/install-expo/index.stories.mdx
@@ -37,8 +37,7 @@ import { Button } from '@gluestack-ui/themed';
 Create a new Expo projects if it doesn't already exist
 
 ```bash
-npm install --global expo-cli
-expo init my-project
+npx create-expo-app my-project
 cd my-project/
 ```
 
@@ -49,13 +48,7 @@ If you wish to install `gluestack-ui` into your existing project, you can procee
 ### Step 1: Install dependencies
 
 ```bash
-yarn add @gluestack-ui/themed @gluestack-style/react react-native-svg@13.4.0
-```
-
-OR
-
-```bash
-npm i @gluestack-ui/themed @gluestack-style/react react-native-svg@13.4.0
+npx expo install @gluestack-ui/themed @gluestack-style/react react-native-svg@13.4.0
 ```
 
 ### Step 1.5: Default Themed.(Optional)
@@ -63,13 +56,7 @@ npm i @gluestack-ui/themed @gluestack-style/react react-native-svg@13.4.0
 `@gluestack-ui/themed` is intentionally designed as an unstyled library, providing you with the flexibility to style your components as you prefer. However, if you want to use the default theme, you can install `@gluestack-ui/config` as well.
 
 ```bash
-yarn add @gluestack-ui/config@latest
-```
-
-OR
-
-```bash
-npm i @gluestack-ui/config@latest
+npx expo install @gluestack-ui/config@latest
 ```
 
 ### Step 2: Configure the GluestackUIProvider


### PR DESCRIPTION
Expo [recommends using `expo install`](https://docs.expo.dev/workflow/using-libraries/#installing-a-third-party-library) when installing third party libraries.