### PR TITLE
docs(animation) - added link to expo demo

### DIFF
--- a/example/storybook/src/styled/plugins/AnimationPlugin/index.stories.mdx
+++ b/example/storybook/src/styled/plugins/AnimationPlugin/index.stories.mdx
@@ -99,4 +99,4 @@ const StyledMotionImage = styled(AnimatedImage, {
 });
 ```
 
-In this example, we're using the `AnimatePresence`, provided by the animation resolver, to wrap the Box component. Internally, it uses `AnimatePresence` from activated animation driver.
+In this example, we're using the `AnimatePresence`, provided by the animation resolver, to wrap the Box component. Internally, it uses `AnimatePresence` from activated animation driver. Here is an [expo snack](https://snack.expo.dev/@gluestack/bounce-animation?platform=web) for a more complete example.


### PR DESCRIPTION
I thought a link to the expo snack used on the landing page would help understand the documentation for animation. 

Added a link to this expo that is shown on the [landing page](https://gluestack.io/style)
<img width="1588" alt="Screenshot 2023-12-20 at 15 55 01" src="https://github.com/gluestack/gluestack-ui/assets/6124450/e1ea32df-963f-4ec2-ac16-0723434c90a8">
