### PR TITLE
Fix benchmark link in docs

### DIFF
--- a/example/storybook/src/ui/performance/overview/index.stories.mdx
+++ b/example/storybook/src/ui/performance/overview/index.stories.mdx
@@ -31,7 +31,7 @@ This results in a smaller and optimized bundle for the application, thus enhanci
 
 ## Benchmark
 
-We tested the performance of a webpage, built with `gluestack-ui` and a large number of elements, using Lighthouse and achieved a **high score of 100 for Performance, 97 for Accessibility, 92 for Best Practices, and 100 for SEO**. You can check out the website and see the Lighthouse report for yourself. You can see more in-depth report [here](ui/docs/performance/benchmarks).
+We tested the performance of a webpage, built with `gluestack-ui` and a large number of elements, using Lighthouse and achieved a **high score of 100 for Performance, 97 for Accessibility, 92 for Best Practices, and 100 for SEO**. You can check out the website and see the Lighthouse report for yourself. You can see more in-depth report [here](/ui/docs/performance/benchmarks).
 
 <img
   src="/images/PerformanceScreenshot.png"


### PR DESCRIPTION
Fix the link to be rooted, previously it would create an invalid link like:

https://gluestack.io/ui/docs/performance/ui/docs/performance/benchmarks

We want

https://gluestack.io/ui/docs/performance/benchmarks