### PR TITLE
Ensuring the library works with node pre 16.9.0

### DIFF
--- a/packages/themed/src/components/FlatList/styled-components/Root.tsx
+++ b/packages/themed/src/components/FlatList/styled-components/Root.tsx
@@ -15,7 +15,7 @@ export default styled(
         const aliases: any = useStyled()?.config?.aliases;
         const newValue = {} as Record<any, string>;
         Object.entries(rawValue).forEach(([key, value]: any) => {
-          if (Object.hasOwn(aliases, key)) {
+          if (aliases?.hasOwnProperty(key)) {
             newValue[`${aliases[key]}`] = resolver(
               value,
               //@ts-ignore

--- a/packages/themed/src/components/KeyboardAvoidingView/styled-components/Root.tsx
+++ b/packages/themed/src/components/KeyboardAvoidingView/styled-components/Root.tsx
@@ -16,7 +16,7 @@ export default styled(
         const aliases = useStyled()?.config?.aliases;
         const newValue = {} as Record<any, string>;
         Object.entries(rawValue).forEach(([key, value]) => {
-          if (Object.hasOwn(aliases, key)) {
+          if (aliases?.hasOwnProperty(key)) {
             newValue[`${aliases[key]}`] = resolver(
               value,
               //@ts-ignore

--- a/packages/themed/src/components/ScrollView/styled-components/Root.tsx
+++ b/packages/themed/src/components/ScrollView/styled-components/Root.tsx
@@ -15,7 +15,7 @@ export default styled(
         const aliases: any = useStyled()?.config?.aliases;
         const newValue = {} as Record<any, string>;
         Object.entries(rawValue).forEach(([key, value]: any) => {
-          if (Object.hasOwn(aliases, key)) {
+          if (aliases?.hasOwnProperty(key)) {
             newValue[`${aliases[key]}`] = resolver(
               value,
               //@ts-ignore

--- a/packages/themed/src/components/SectionList/styled-components/Root.tsx
+++ b/packages/themed/src/components/SectionList/styled-components/Root.tsx
@@ -14,7 +14,7 @@ export default styled(
         const aliases: any = useStyled()?.config?.aliases;
         const newValue = {} as Record<any, string>;
         Object.entries(rawValue).forEach(([key, value]: any) => {
-          if (Object.hasOwn(aliases, key)) {
+          if (aliases?.hasOwnProperty(key)) {
             newValue[`${aliases[key]}`] = resolver(
               value,
               //@ts-ignore


### PR DESCRIPTION
# Issue

Tags: `react-native` `android` `node`

The ability to use `Object.hasOwn` is limited to node > 16.9.0. In developing a react native application, I'm hitting this error (on Android):

<img width="320" alt="Screenshot 2024-01-09 at 3 05 03 PM" src="https://github.com/gluestack/gluestack-ui/assets/1092915/98b1b7e3-8c40-49eb-929d-3f455e77749a">

# Suggestion

Remove instances of `hasOwn` and replace them with `hasOwnProperty` to ensure the library is compatible with a wider range of apps.