### PR TITLE
fix: direction prop name modified

### DIFF
--- a/example/storybook/src/ui/components/Forms/Button/ButtonGroup.stories.tsx
+++ b/example/storybook/src/ui/components/Forms/Button/ButtonGroup.stories.tsx
@@ -19,9 +19,9 @@ const ButtonGroupMeta: ComponentMeta<any> = {
       control: 'select',
       options: ['xs', 'sm', 'md', 'lg', 'xl'],
     },
-    direction: {
+    flexDirection: {
       control: 'select',
-      options: ['row', 'column'],
+      options: ['row', 'column', 'row-reverse', 'column-reverse'],
     },
     isAttached: {
       control: 'boolean',

--- a/example/storybook/src/ui/components/Forms/Button/ButtonGroup.tsx
+++ b/example/storybook/src/ui/components/Forms/Button/ButtonGroup.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 const ButtonGroupBasic = ({ ...props }) => {
   return (
-    // @ts-ignore
     <ButtonGroup {...props}>
       <Button>
         <ButtonText>Button 1</ButtonText>

--- a/example/storybook/src/ui/components/Forms/Button/index.stories.mdx
+++ b/example/storybook/src/ui/components/Forms/Button/index.stories.mdx
@@ -289,11 +289,13 @@ Contains all group related layout style props and actions. It inherits all the p
         <Table.TR>
           <Table.TD>
             <Table.TText>
-              <InlineCode>direction</InlineCode>
+              <InlineCode>flexDirection</InlineCode>
             </Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>'column' | 'row'</Table.TText>
+            <Table.TText>
+              'row' | 'column' | 'row-reverse' | 'column-reverse'
+            </Table.TText>
           </Table.TD>
           <Table.TD>
             <Table.TText>'row'</Table.TText>

--- a/packages/unstyled/button/src/ButtonGroup.tsx
+++ b/packages/unstyled/button/src/ButtonGroup.tsx
@@ -5,7 +5,7 @@ export const ButtonGroup = (StyledButtonGroup: any) =>
   forwardRef(
     (
       {
-        direction = 'row',
+        flexDirection = 'row',
         isAttached,
         isDisabled,
         children,
@@ -15,6 +15,11 @@ export const ButtonGroup = (StyledButtonGroup: any) =>
       }: any,
       ref?: any
     ) => {
+      const direction = flexDirection.includes('reverse')
+        ? flexDirection === 'column-reverse'
+          ? 'column'
+          : 'row'
+        : flexDirection;
       let computedChildren;
       let childrenArray = React.Children.toArray(flattenChildren(children));
       childrenArray =
@@ -78,7 +83,7 @@ export const ButtonGroup = (StyledButtonGroup: any) =>
       if (computedChildren)
         return (
           <StyledButtonGroup
-            flexDirection={direction}
+            flexDirection={flexDirection}
             {...props}
             ref={ref}
             {...gapProp}

--- a/packages/unstyled/button/src/types.ts
+++ b/packages/unstyled/button/src/types.ts
@@ -28,7 +28,7 @@ export interface IButtonGroupProps {
    * The direction of the Stack Items.
    * @default row
    */
-  direction?: 'column' | 'row';
+  flexDirection?: 'row' | 'column' | 'row-reverse' | 'column-reverse';
   /**
    *
    */


### PR DESCRIPTION
In this pull request (PR), 

I modified the prop name from 'direction' to 'flexDirection' in the button group components. Now, it accepts values such as 'row', 'column', 'row-reverse', and 'column-reverse'. 

Additionally, I have updated the documentation to reflect these changes.