### PR TITLE
chore: bump version of expo-linear-gradient for expo 50 compatability

### DIFF
--- a/packages/unstyled/linear-gradient/package.json
+++ b/packages/unstyled/linear-gradient/package.json
@@ -43,7 +43,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "expo-linear-gradient": "12.3.0"
+    "expo-linear-gradient": "12.7.0"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12615,10 +12615,10 @@ expo-keep-awake@~11.0.1:
   resolved "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-11.0.1.tgz"
   integrity sha512-44ZjgLE4lnce2d40Pv8xsjMVc6R5GvgHOwZfkLYtGmgYG9TYrEJeEj5UfSeweXPL3pBFhXKfFU8xpGYMaHdP0A==
 
-expo-linear-gradient@12.3.0:
-  version "12.3.0"
-  resolved "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-12.3.0.tgz"
-  integrity sha512-f9e+Oxe5z7fNQarTBZXilMyswlkbYWQHONVfq8MqmiEnW3h9XsxxmVJLG8uVQSQPUsbW+x1UUT/tnU6mkMWeLg==
+expo-linear-gradient@12.7.0:
+  version "12.7.0"
+  resolved "https://registry.yarnpkg.com/expo-linear-gradient/-/expo-linear-gradient-12.7.0.tgz#95516021b20a6fc3b886778bce492be34df48fa0"
+  integrity sha512-4a8m+yf0gcPsBO6MEGz2fgGTdpLzGWuGE8biMN5L/vWfP4L7Erve3dTU1gIr0uYxeTH1RjGtdllqOQsx36WIyw==
 
 expo-linear-gradient@^12.3.0:
   version "12.5.0"


### PR DESCRIPTION
Fixes #1673 