### PR TITLE
fix: added overflow property for inputField

### DIFF
--- a/packages/config/src/theme/Input.ts
+++ b/packages/config/src/theme/Input.ts
@@ -29,6 +29,7 @@ export const Input = createStyle({
   '_input': {
     py: 'auto',
     px: '$3',
+    overflow: 'hidden',
   },
 
   '_icon': {


### PR DESCRIPTION
In this PR I added `overflow: 'hidden'` for inputField because text is coming out for very small screen size