### PR TITLE
fix: issue with missing -bg with platform specific doc

### DIFF
--- a/example/storybook/src/ui/styling/platform-specific/index.stories.mdx
+++ b/example/storybook/src/ui/styling/platform-specific/index.stories.mdx
@@ -41,7 +41,7 @@ We can provide platform specific styles in the `sx` prop of the component. The `
           <Button
             $ios-bg="$red500"
             $web-bg="$green500"
-            $android="$yellow500"
+            $android-bg="$yellow500"
             >
             <ButtonText>Button</ButtonText>
           </Button>


### PR DESCRIPTION
I just added the missing -bg to the Android-specific doc.