### PR TITLE
Update types.ts in Menu

### DIFF
--- a/packages/unstyled/menu/src/types.ts
+++ b/packages/unstyled/menu/src/types.ts
@@ -44,12 +44,20 @@ export interface InterfaceMenuProps {
     | 'right'
     | 'top left'
     | 'top right'
+    | 'top start'
+    | 'top end'
     | 'bottom left'
     | 'bottom right'
+    | 'bottom start'
+    | 'bottom end'
     | 'right top'
     | 'right bottom'
+    | 'right start'
+    | 'right end'
     | 'left top'
-    | 'left bottom';
+    | 'left bottom'
+    | 'left start'
+    | 'left end';
 
   children?: any;
   /** Determines whether menu should flip or not


### PR DESCRIPTION
## Motivation
When I see the document of Menu component, I find the type error.
https://gluestack.io/ui/docs/components/overlay/menu

We can select the value I added in document, but these is not support by Type.

// It stays in beta.
// If you plan to add them and change the value, you can ignore.

