### PR TITLE
fix: input readOnly

### DIFF
--- a/packages/unstyled/input/src/Input.tsx
+++ b/packages/unstyled/input/src/Input.tsx
@@ -87,7 +87,7 @@ export const Input = (StyledInput: any) =>
           aria-selected={isFocused}
           // ios accessibility
           accessibilityElementsHidden={isDisabled || inputProps.isDisabled}
-          readOnly={editableProp}
+          readOnly={!editableProp}
           onKeyPress={(e: any) => {
             e.persist();
             onKeyPress && onKeyPress(e);


### PR DESCRIPTION
`@gluestack-ui/input@0.1.26` introduced a bug to `<Input>`: it flips the behavior of `isDisabled/isReadOnly`.

The prop `editable` was deprecated in favor of `readOnly` which expresses the opposite behavior, but [the value passed to the prop remained the same](https://github.com/gluestack/gluestack-ui/commit/892999bc7c68ddafbf28d79ae0c0286106d0dfbd?diff=unified&w=1#diff-2111d1ad8967155c55f683327c8bd3067d3b3bdb1d2017c264fd4f7582700c25L89) instead of being negated.