### PR TITLE
fix: Remove aria-selected from text inputs on web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,7 @@ yarn-error.log*
 .turbo
 .vercel
 
+# jetBrains IDE files
+.idea
+
 packages/gluestack-style

--- a/packages/unstyled/input/src/Input.tsx
+++ b/packages/unstyled/input/src/Input.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useMemo } from 'react';
+import { Platform } from 'react-native';
 import { useFormControl } from '@gluestack-ui/form-control';
 import { useInput } from './InputContext';
 import { mergeRefs } from '@gluestack-ui/utils';
@@ -84,7 +85,7 @@ export const Input = (StyledInput: any) =>
           aria-required={isRequired || inputProps.isRequired}
           aria-invalid={isInvalid || inputProps.isInvalid}
           aria-disabled={isDisabled || inputProps.isDisabled}
-          aria-selected={isFocused}
+          aria-selected={Platform.OS !== 'web' ? isFocused : undefined}
           // ios accessibility
           accessibilityElementsHidden={isDisabled || inputProps.isDisabled}
           readOnly={!editableProp}

--- a/packages/unstyled/textarea/src/Textarea.tsx
+++ b/packages/unstyled/textarea/src/Textarea.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react';
+import { Platform } from 'react-native';
 import { useFormControl } from '@gluestack-ui/form-control';
 import { useTextarea } from './TextareaContext';
 
@@ -60,7 +61,7 @@ export const Textarea = (StyledTextarea: any) =>
           aria-required={isRequired || textareaProps.isRequired}
           aria-invalid={isInvalid || textareaProps.isInvalid}
           aria-disabled={isDisabled || textareaProps.isDisabled}
-          aria-selected={isFocused}
+          aria-selected={Platform.OS !== 'web' ? isFocused : undefined}
           aria-hidden={isDisabled}
           editable={isDisabled || isReadOnly ? false : true}
           disabled={isDisabled || textareaProps.isDisabled}


### PR DESCRIPTION
Aria-selected is not valid on input for web

>The aria-selected attribute indicates the current "selected" state for gridcell, option, row and tab roles. 
...
For other roles, the currently selected state is set with aria-current, or possibly aria-checked or aria-pressed, depending on the role.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected

Screenshot from storybook in my repo with A11y accessibility warnings setup:
<img width="1190" alt="image" src="https://github.com/gluestack/gluestack-ui/assets/22333355/3a8bbe50-69d4-45e5-9eb6-dad7e9a5a92c">
