### PR TITLE
fix/hstack-vstack-docs

### DIFF
--- a/example/storybook-nativewind/src/components/HStack/index.nw.stories.mdx
+++ b/example/storybook-nativewind/src/components/HStack/index.nw.stories.mdx
@@ -50,7 +50,7 @@ This is an illustration of **HStack** component.
       argsType: {
         space: {
           control: 'select',
-          options: ['none', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
+          options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
           default: 'md',
         },
         reversed: {
@@ -182,7 +182,7 @@ HStack component is created using View component from react-native. It extends a
             <Table.TText>-</Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>{`It sets the space between children.`}</Table.TText>
+            <Table.TText>{`It sets the space between children. By default there is no space between the HStack items.`}</Table.TText>
           </Table.TD>
         </Table.TR>
         <Table.TR>
@@ -195,7 +195,7 @@ HStack component is created using View component from react-native. It extends a
             <Table.TText>{`boolean`}</Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>-</Table.TText>
+            <Table.TText>false</Table.TText>
           </Table.TD>
           <Table.TD>
             <Table.TText>{`When true, it places the HStack items in reverse direction.`}</Table.TText>

--- a/example/storybook-nativewind/src/components/HStack/index.themed.stories.mdx
+++ b/example/storybook-nativewind/src/components/HStack/index.themed.stories.mdx
@@ -51,7 +51,7 @@ This is an illustration of **HStack** component.
       argsType: {
         space: {
           control: 'select',
-          options: ['none', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
+          options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
           default: 'md',
         },
         reversed: {
@@ -165,7 +165,7 @@ HStack component is created using View component from react-native. It extends a
             <Table.TText>-</Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>{`It sets the space between children.`}</Table.TText>
+            <Table.TText>{`It sets the space between children. By default there is no space between the HStack items.`}</Table.TText>
           </Table.TD>
         </Table.TR>
         <Table.TR>
@@ -178,7 +178,7 @@ HStack component is created using View component from react-native. It extends a
             <Table.TText>{`boolean`}</Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>-</Table.TText>
+            <Table.TText>false</Table.TText>
           </Table.TD>
           <Table.TD>
             <Table.TText>{`When true, it places the HStack items in reverse direction.`}</Table.TText>

--- a/example/storybook-nativewind/src/components/VStack/index.nw.stories.mdx
+++ b/example/storybook-nativewind/src/components/VStack/index.nw.stories.mdx
@@ -55,7 +55,7 @@ This is an illustration of **VStack** component.
     argsType: {
       space: {
         control: 'select',
-          options: ['none', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
+          options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
           default: 'md',
         },
       reversed: {
@@ -192,7 +192,7 @@ VStack component is created using View component from react-native. It extends a
             <Table.TText>-</Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>{`It sets the space between children.`}</Table.TText>
+            <Table.TText>{`It sets the space between children. By default there is no space between the VStack items.`}</Table.TText>
           </Table.TD>
         </Table.TR>
         <Table.TR>
@@ -205,7 +205,7 @@ VStack component is created using View component from react-native. It extends a
             <Table.TText>boolean</Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>-</Table.TText>
+            <Table.TText>false</Table.TText>
           </Table.TD>
           <Table.TD>
             <Table.TText>{`When true, it places the VStack items in reverse direction.`}</Table.TText>

--- a/example/storybook/src/ui/components/Layout/HStack/index.stories.mdx
+++ b/example/storybook/src/ui/components/Layout/HStack/index.stories.mdx
@@ -48,8 +48,8 @@ This is an illustration of a **Themed HStack** component with default configurat
       argsType: {
         space: {
           control: 'select',
-          options: ['none', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
-          default: 'none',
+          options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
+          default: 'md',
         },
         reversed: {
           control: 'boolean',
@@ -134,7 +134,7 @@ HStack component is created using View component from react-native. It extends a
             <Table.TText>-</Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>{`It sets the space between children.`}</Table.TText>
+            <Table.TText>{`It sets the space between children. By default there is no space between the HStack items.`}</Table.TText>
           </Table.TD>
         </Table.TR>
         <Table.TR>
@@ -147,7 +147,7 @@ HStack component is created using View component from react-native. It extends a
             <Table.TText>{`boolean`}</Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>-</Table.TText>
+            <Table.TText>false</Table.TText>
           </Table.TD>
           <Table.TD>
             <Table.TText>{`When true, it places the HStack items in reverse direction.`}</Table.TText>

--- a/example/storybook/src/ui/components/Layout/VStack/index.stories.mdx
+++ b/example/storybook/src/ui/components/Layout/VStack/index.stories.mdx
@@ -54,7 +54,7 @@ This is an illustration of a **Themed VStack** component with default configurat
       argsType: {
         space: {
           control: 'select',
-          options: ['none', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
+          options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
           default: 'md',
         },
         reversed: {
@@ -144,7 +144,7 @@ VStack component is created using View component from react-native. It extends a
             <Table.TText>-</Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>{`It sets the space between children.`}</Table.TText>
+            <Table.TText>{`It sets the space between children. By default there is no space between the VStack items.`}</Table.TText>
           </Table.TD>
         </Table.TR>
         <Table.TR>
@@ -157,7 +157,7 @@ VStack component is created using View component from react-native. It extends a
             <Table.TText>boolean</Table.TText>
           </Table.TD>
           <Table.TD>
-            <Table.TText>-</Table.TText>
+            <Table.TText>false</Table.TText>
           </Table.TD>
           <Table.TD>
             <Table.TText>{`When true, it places the VStack items in reverse direction.`}</Table.TText>


### PR DESCRIPTION
In this PR I've removed the none "value" of the "space" variant from the knob examples of HStack and VStack docs.