### PR TITLE
Make composeEventHandlers accept a variable amount of handlers

### DIFF
--- a/packages/unstyled/utils/src/composeEventHandlers.ts
+++ b/packages/unstyled/utils/src/composeEventHandlers.ts
@@ -1,11 +1,9 @@
-export function composeEventHandlers<E>(
-  originalEventHandler?: null | ((event: E) => void),
-  ourEventHandler?: (event: E) => void
-) {
+export function composeEventHandlers<E>(...args: (null | undefined | ((event: E) => void))[]) {
   return function handleEvent(event: E) {
     try {
-      originalEventHandler?.(event);
-      ourEventHandler?.(event);
+      for (let i = 0; i < args.length; i++) {
+        args[i]?.(event);
+      }
     } catch (e) {
       //
     }


### PR DESCRIPTION
This has the benefit of simplifying code where composing more than 2 handlers is necessary. This happens a lot in the code base, specifically around `useFocus` and `useFocusRing`.

Example where this is helpful:

```ts
          // @ts-ignore - web only
          onFocus={composeEventHandlers(
            composeEventHandlers(props?.onFocus, focusProps.onFocus),
            focusRingProps.onFocus
          )}
          // @ts-ignore - web only
          onBlur={composeEventHandlers(
            composeEventHandlers(props?.onBlur, focusProps.onBlur),
            focusRingProps.onBlur
          )}
```

becomes

```ts
          // @ts-ignore - web only
          onFocus={composeEventHandlers(props?.onFocus, focusProps.onFocus, focusRingProps.onFocus)}
          // @ts-ignore - web only
          onBlur={composeEventHandlers(props?.onBlur, focusProps.onBlur, focusRingProps.onBlur)}
```