### PR TITLE
fix: rn-web rtl issues in Menu & Tooltip

### DIFF
--- a/packages/unstyled/menu/src/MenuPopover/Popover.web.tsx
+++ b/packages/unstyled/menu/src/MenuPopover/Popover.web.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { View, I18nManager } from 'react-native';
 import { usePopover, DismissButton, Overlay } from '@react-aria/overlays';
 import { MenuContext } from '../MenuContext';
 export function Popover({ StyledBackdrop, ...props }: any) {
@@ -17,6 +17,15 @@ export function Popover({ StyledBackdrop, ...props }: any) {
 
   if (!state.isOpen) {
     return null;
+  }
+
+  // Make position of Popover correct in RTL.
+  if (I18nManager.getConstants().isRTL) {
+    popoverProps.style = {
+      ...popoverProps.style,
+      right: popoverProps?.style?.left || 'unset',
+      left: 'unset',
+    };
   }
 
   return (

--- a/packages/unstyled/tooltip/src/TooltipContent.tsx
+++ b/packages/unstyled/tooltip/src/TooltipContent.tsx
@@ -3,7 +3,7 @@ import { useTooltipContext } from './context';
 import { mergeRefs } from '@gluestack-ui/utils';
 import { useOverlayPosition } from '@react-native-aria/overlays';
 import { OverlayAnimatePresence } from './OverlayAnimatePresence';
-import { Platform } from 'react-native';
+import { Platform, I18nManager } from 'react-native';
 
 export function TooltipContent<StyledTooltipContentProps>(
   StyledTooltipContent: React.ComponentType<StyledTooltipContentProps>,
@@ -38,6 +38,15 @@ export function TooltipContent<StyledTooltipContentProps>(
       };
     }
     const mergedRef = mergeRefs([ref, overlayRef]);
+
+    // Make position of Tooltip correct in RTL.
+    if (Platform.OS === 'web' && I18nManager.getConstants().isRTL) {
+      overlayProps.style = {
+        ...overlayProps.style,
+        right: overlayProps?.style?.left,
+      };
+      delete overlayProps?.style?.left;
+    }
 
     return (
       <OverlayAnimatePresence


### PR DESCRIPTION
As of now the components with an overlay do not respect the RTL layout using react-native-web (tested on 0.17.7).


The PopOver and the Toasts are on right instead of left (away from their triggerElement).
Added conditions to check if the current layout is RTL and flip the styles accordingly.