### PR TITLE
fix(toast): isActive always false, "any" types, duplicate toasts with same id

### DIFF
--- a/.changeset/few-rules-refuse.md
+++ b/.changeset/few-rules-refuse.md
@@ -1,0 +1,10 @@
+---
+'@gluestack-ui/toast': patch
+---
+
+Multple fixes to toast
+
+- Fixed `isActive` always returning false
+- Removed almost all instances of `any`, replaced with actual types
+- Fixed duplicate toasts when calling `show` with an existing id
+- Removed unnecessary `@ts-ignore` usages

--- a/packages/unstyled/toast/src/OverlayAnimatePresence.tsx
+++ b/packages/unstyled/toast/src/OverlayAnimatePresence.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable react-hooks/exhaustive-deps */
+import { ExitAnimationContext } from '@gluestack-ui/overlay';
 import React, { forwardRef } from 'react';
 import { Animated } from 'react-native';
-import { ExitAnimationContext } from '@gluestack-ui/overlay';
 
-const defaultTransitionConfig: any = {
+const defaultTransitionConfig = {
   type: 'timing',
   useNativeDriver: true,
   duration: 0,
   delay: 0,
-};
+} as const;
 
 export const OverlayAnimatePresence = forwardRef(
   ({ children, visible = false, AnimatePresence, onExit }: any, ref?: any) => {
@@ -27,8 +27,6 @@ export const OverlayAnimatePresence = forwardRef(
 
         if (AnimatePresence) {
           Animated.sequence([
-            // @ts-ignore - delay is present in defaultTransitionConfig
-            //@ts-ignore
             Animated[transition.type ?? 'timing'](animateValue, {
               toValue: startAnimation,
               useNativeDriver: true,

--- a/packages/unstyled/toast/src/ToastContext.ts
+++ b/packages/unstyled/toast/src/ToastContext.ts
@@ -1,16 +1,16 @@
 import { createContext } from 'react';
-import type { IToastContext } from './types';
+import type { IToastContext, IToastInfo } from './types';
 
 export const ToastContext = createContext<IToastContext>({
-  toastInfo: {},
+  toastInfo: {} as IToastInfo,
   setToastInfo: () => {},
-  setToast: () => {},
+  setToast: () => '',
   removeToast: () => {},
   hideAll: () => {},
   isActive: () => false,
   visibleToasts: {},
   setVisibleToasts: () => {},
   hideToast: () => {},
-  AnimationWrapper: null,
-  AnimatePresence: null,
+  AnimationWrapper: { current: null },
+  AnimatePresence: { current: null },
 });

--- a/packages/unstyled/toast/src/ToastList.tsx
+++ b/packages/unstyled/toast/src/ToastList.tsx
@@ -1,12 +1,11 @@
 /* eslint-disable react-native/no-inline-styles */
-import React from 'react';
-import { ToastContext } from './ToastContext';
-import { Overlay } from '@gluestack-ui/overlay';
-import { SafeAreaView } from 'react-native';
-import { View, Platform } from 'react-native';
 import { useKeyboardBottomInset } from '@gluestack-ui/hooks';
-import type { IToast } from './types';
+import { Overlay } from '@gluestack-ui/overlay';
+import React from 'react';
+import { Platform, SafeAreaView, View } from 'react-native';
 import { OverlayAnimatePresence } from './OverlayAnimatePresence';
+import { ToastContext } from './ToastContext';
+import type { IToast, ToastPlacement } from './types';
 
 const initialAnimationOffset = 24;
 const transitionConfig: any = {
@@ -61,12 +60,12 @@ export const ToastList = () => {
     AnimationWrapper,
     AnimatePresence: ContextAnimatePresence,
   } = React.useContext(ToastContext);
-  const AnimationView = AnimationWrapper.current;
-  const AnimatePresence = ContextAnimatePresence.current;
+  const AnimationView = AnimationWrapper?.current;
+  const AnimatePresence = ContextAnimatePresence?.current;
 
   const bottomInset = useKeyboardBottomInset() * 2;
   const getPositions = () => {
-    return Object.keys(toastInfo);
+    return Object.keys(toastInfo) as (keyof typeof toastInfo)[];
   };
 
   let hasToastOnOverlay = false;
@@ -76,7 +75,7 @@ export const ToastList = () => {
 
   return getPositions().length > 0 ? (
     <Overlay isOpen={hasToastOnOverlay} isKeyboardDismissable={false}>
-      {getPositions().map((position: string) => {
+      {getPositions().map((position: ToastPlacement) => {
         if (Object.keys(POSITIONS).includes(position))
           return (
             <View
@@ -84,9 +83,9 @@ export const ToastList = () => {
               style={{
                 justifyContent: 'center',
                 margin: 'auto',
+                //@ts-expect-error it is properly defined above per-platform
                 position: toastPositionStyle,
                 pointerEvents: 'box-none',
-                //@ts-ignore
                 ...POSITIONS[position],
               }}
             >

--- a/packages/unstyled/toast/src/types.ts
+++ b/packages/unstyled/toast/src/types.ts
@@ -1,4 +1,17 @@
-import type { ReactNode } from 'react';
+import type {
+  Dispatch,
+  MutableRefObject,
+  ReactNode,
+  SetStateAction,
+} from 'react';
+
+export type ToastPlacement =
+  | 'top'
+  | 'top right'
+  | 'top left'
+  | 'bottom'
+  | 'bottom left'
+  | 'bottom right';
 
 export interface InterfaceToastProps {
   /**
@@ -9,7 +22,7 @@ export interface InterfaceToastProps {
   /**
    * The `id` of the toast. Mostly used when you need to prevent duplicate. By default, we generate a unique `id` for each toast
    */
-  id?: any;
+  id?: string;
   /**
    * Callback function to run side effects after the toast has closed.
    */
@@ -18,17 +31,11 @@ export interface InterfaceToastProps {
    * The placement of the toast. Defaults to bottom
    * @default bottom
    */
-  placement?:
-    | 'top'
-    | 'top right'
-    | 'top left'
-    | 'bottom'
-    | 'bottom left'
-    | 'bottom right';
+  placement?: ToastPlacement;
   /**
-   * Render a component toast component. Any component passed will receive 2 props: `id` and `onClose`.
+   * Render a component toast component. Any component passed will receive 1 prop: `id`
    */
-  render?: (props: any) => ReactNode;
+  render?: (props: ToastComponentProps) => ReactNode;
   /**
    * If true and the keyboard is opened, the Toast will move up equivalent to the keyboard height.
    * @default false
@@ -39,33 +46,41 @@ export interface InterfaceToastProps {
    * container Style object for the toast
    * @default 0
    */
-  containerStyle?: any;
+  containerStyle?: React.CSSProperties;
 }
 
-export type IToast = {
-  id: number;
-  component: any;
+export interface ToastComponentProps {
+  id: string;
+}
+
+export interface VisibleToasts {
+  [key: string]: boolean;
+}
+
+export interface IToast {
+  id: string;
+  component: ReactNode;
   config?: IToastProps;
-};
+}
 
 export type IToastInfo = {
-  [key in any]: Array<IToast>;
+  [key in ToastPlacement]: Array<IToast>;
 };
 
 export type IToastContext = {
   toastInfo: IToastInfo;
-  setToastInfo: any;
-  setToast: (props: IToastProps) => any;
-  removeToast: (id: any) => void;
+  setToastInfo: Dispatch<SetStateAction<IToastInfo>>;
+  setToast: (props: IToastProps) => string;
+  removeToast: (id: string) => void;
   hideAll: () => void;
-  isActive: (id: any) => boolean;
-  visibleToasts: any;
-  setVisibleToasts: any;
-  hideToast: (id: any) => void;
+  isActive: (id: string) => boolean;
+  visibleToasts: VisibleToasts;
+  setVisibleToasts: Dispatch<SetStateAction<VisibleToasts>>;
+  hideToast: (id: string) => void;
   avoidKeyboard?: boolean;
   bottomInset?: number;
-  AnimationWrapper?: any;
-  AnimatePresence?: any;
+  AnimationWrapper: MutableRefObject<any | null>;
+  AnimatePresence: MutableRefObject<any | null>;
 };
 
 export type IToastComponentType<


### PR DESCRIPTION
Multple fixes to toast

- Fixed `isActive` always returning false
- Removed almost all instances of `any`, replaced with actual types
- Fixed duplicate toasts when calling `show` with an existing id
- Removed unnecessary `@ts-ignore` usages