### PR TITLE
fix: typo in the code example about GluestackUIStyledProvider

### DIFF
--- a/example/storybook/src/ui/components/Provider/GluestackUIProvider/index.stories.mdx
+++ b/example/storybook/src/ui/components/Provider/GluestackUIProvider/index.stories.mdx
@@ -96,11 +96,11 @@ import { config } from '@gluestack-ui/config';
 
 export default function App() {
   return (
-    <GluestackUIProvider config={config}>
+    <GluestackUIStyledProvider config={config}>
       <Button>
         <ButtonText>Hello World</ButtonText>
       </Button>
-    </GluestackUIProvider>
+    </GluestackUIStyledProvider>
   )
 }
 ```


### PR DESCRIPTION
I found a typo in a code example here: https://gluestack.io/ui/docs/components/provider/gluestack-uiprovider

The example is about: `GluestackUIStyledProvider` but in the code snippet the import is from `GluestackUIProvider ` (see the screenshot)

<img width="987" alt="image" src="https://github.com/user-attachments/assets/83e440e3-77fb-425d-9f9d-1f4582e731e4">
