### PR TITLE
feat: allow overriding of role prop for icons

### DIFF
--- a/packages/unstyled/icon/src/createIcon/index.tsx
+++ b/packages/unstyled/icon/src/createIcon/index.tsx
@@ -65,7 +65,12 @@ export function createIcon<IconProps>({
       ...props,
     };
 
-    const { stroke = 'currentColor', color, ...resolvedProps } = finalProps;
+    const {
+      stroke = 'currentColor',
+      color,
+      role = 'img',
+      ...resolvedProps
+    } = finalProps;
     let type = resolvedProps.type;
     if (type === undefined) {
       type = 'svg';
@@ -93,7 +98,7 @@ export function createIcon<IconProps>({
       <Root
         {...resolvedProps}
         {...colorProps}
-        role="img"
+        role={role}
         ref={ref}
         {...sizeProps}
         {...sizeStyle}

--- a/packages/unstyled/icon/src/createIcon/index.web.tsx
+++ b/packages/unstyled/icon/src/createIcon/index.web.tsx
@@ -64,7 +64,12 @@ export function createIcon<IconProps>({
       ...props,
     };
 
-    const { stroke = 'currentColor', color, ...resolvedProps } = finalProps;
+    const {
+      stroke = 'currentColor',
+      color,
+      role = 'img',
+      ...resolvedProps
+    } = finalProps;
     let type = resolvedProps.type;
     if (type === undefined) {
       type = 'svg';
@@ -92,7 +97,7 @@ export function createIcon<IconProps>({
       <Root
         {...resolvedProps}
         {...colorProps}
-        role="img"
+        role={role}
         ref={ref}
         {...sizeProps}
         {...sizeStyle}


### PR DESCRIPTION
Currently, there is no way to override the `role="img"` prop that Gluestack automatically supplies to icons. We should be able to override this to pass something like `role="presentation"` for icons that are purely decorative and shouldn't be called out by screen readers.