### PR TITLE
Fixes #2450 -- Actionsheet scroll prevention only when backdrop is used

### DIFF
--- a/packages/unstyled/actionsheet/src/ActionsheetBackdrop.tsx
+++ b/packages/unstyled/actionsheet/src/ActionsheetBackdrop.tsx
@@ -8,11 +8,11 @@ function ActionsheetBackdrop<T>(
   AnimatePresence?: React.ComponentType<any>
 ) {
   return forwardRef(
-    ({ children, ...props }: T & { children?: any }, ref?: any) => {
+    ({ children, preventScroll = true, ...props }: T & { children?: any }, ref?: any) => {
       const { closeOnOverlayClick, handleClose, backdropVisible } =
         React.useContext(ActionsheetContext);
 
-      usePreventScroll();
+      usePreventScroll({ isDisabled: preventScroll });
 
       return (
         <OverlayAnimatePresence

--- a/packages/unstyled/actionsheet/src/ActionsheetBackdrop.tsx
+++ b/packages/unstyled/actionsheet/src/ActionsheetBackdrop.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 import { ActionsheetContext } from './context';
 import { OverlayAnimatePresence } from './OverlayAnimatePresence';
+import { usePreventScroll } from '@react-native-aria/overlays';
 
 function ActionsheetBackdrop<T>(
   StyledActionsheetBackdrop: React.ComponentType<T>,
@@ -10,6 +11,8 @@ function ActionsheetBackdrop<T>(
     ({ children, ...props }: T & { children?: any }, ref?: any) => {
       const { closeOnOverlayClick, handleClose, backdropVisible } =
         React.useContext(ActionsheetContext);
+
+      usePreventScroll();
 
       return (
         <OverlayAnimatePresence

--- a/packages/unstyled/actionsheet/src/ActionsheetBackdrop.tsx
+++ b/packages/unstyled/actionsheet/src/ActionsheetBackdrop.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef } from 'react';
 import { ActionsheetContext } from './context';
 import { OverlayAnimatePresence } from './OverlayAnimatePresence';
-import { usePreventScroll } from '@react-native-aria/overlays';
 
 function ActionsheetBackdrop<T>(
   StyledActionsheetBackdrop: React.ComponentType<T>,

--- a/packages/unstyled/actionsheet/src/ActionsheetBackdrop.tsx
+++ b/packages/unstyled/actionsheet/src/ActionsheetBackdrop.tsx
@@ -8,11 +8,9 @@ function ActionsheetBackdrop<T>(
   AnimatePresence?: React.ComponentType<any>
 ) {
   return forwardRef(
-    ({ children, preventScroll = true, ...props }: T & { children?: any }, ref?: any) => {
+    ({ children, ...props }: T & { children?: any }, ref?: any) => {
       const { closeOnOverlayClick, handleClose, backdropVisible } =
         React.useContext(ActionsheetContext);
-
-      usePreventScroll({ isDisabled: preventScroll });
 
       return (
         <OverlayAnimatePresence

--- a/packages/unstyled/actionsheet/src/ActionsheetContent.tsx
+++ b/packages/unstyled/actionsheet/src/ActionsheetContent.tsx
@@ -15,6 +15,7 @@ import { FocusScope } from '@react-native-aria/focus';
 import { mergeRefs } from '@gluestack-ui/utils';
 import { useDialog } from '@react-native-aria/dialog';
 
+import { usePreventScroll } from '@react-native-aria/overlays';
 const windowHeight = Dimensions.get('screen').height;
 function ActionsheetContent(
   StyledActionsheetContent: any,
@@ -26,6 +27,13 @@ function ActionsheetContent(
         children,
         _experimentalContent = false,
         focusScope = true,
+        /**
+         * @deprecated In the future this property will be removed and the
+         * default behavior will be not to prevent scroll. You can still
+         * prevent scroll by using the ActionsheetBackdrop component and
+         * its `preventScroll` property, which is set to `true` by default.
+         **/
+        preventScroll = true,
         ...props
       }: any,
       ref?: any
@@ -39,6 +47,8 @@ function ActionsheetContent(
         finalFocusRef,
         snapPoints,
       } = React.useContext(ActionsheetContext);
+
+      usePreventScroll({ isDisabled: preventScroll })
 
       const pan = React.useRef(new Animated.ValueXY()).current;
       const contentSheetHeight = React.useRef(0);

--- a/packages/unstyled/actionsheet/src/ActionsheetContent.tsx
+++ b/packages/unstyled/actionsheet/src/ActionsheetContent.tsx
@@ -48,7 +48,7 @@ function ActionsheetContent(
         snapPoints,
       } = React.useContext(ActionsheetContext);
 
-      usePreventScroll({ isDisabled: preventScroll })
+      usePreventScroll({ isDisabled: preventScroll });
 
       const pan = React.useRef(new Animated.ValueXY()).current;
       const contentSheetHeight = React.useRef(0);

--- a/packages/unstyled/actionsheet/src/ActionsheetContent.tsx
+++ b/packages/unstyled/actionsheet/src/ActionsheetContent.tsx
@@ -15,7 +15,6 @@ import { FocusScope } from '@react-native-aria/focus';
 import { mergeRefs } from '@gluestack-ui/utils';
 import { useDialog } from '@react-native-aria/dialog';
 
-import { usePreventScroll } from '@react-native-aria/overlays';
 const windowHeight = Dimensions.get('screen').height;
 function ActionsheetContent(
   StyledActionsheetContent: any,
@@ -40,8 +39,6 @@ function ActionsheetContent(
         finalFocusRef,
         snapPoints,
       } = React.useContext(ActionsheetContext);
-
-      usePreventScroll();
 
       const pan = React.useRef(new Animated.ValueXY()).current;
       const contentSheetHeight = React.useRef(0);

--- a/packages/unstyled/actionsheet/src/ActionsheetContent.tsx
+++ b/packages/unstyled/actionsheet/src/ActionsheetContent.tsx
@@ -27,12 +27,6 @@ function ActionsheetContent(
         children,
         _experimentalContent = false,
         focusScope = true,
-        /**
-         * @deprecated In the future this property will be removed and the
-         * default behavior will be not to prevent scroll. You can still
-         * prevent scroll by using the ActionsheetBackdrop component and
-         * its `preventScroll` property, which is set to `true` by default.
-         **/
         preventScroll = true,
         ...props
       }: any,


### PR DESCRIPTION
With this change the scroll is prevented only when the Actionsheet backdrop component is used, allowing the actionsheet to be used to create UIs similar to Apple Maps and many other, where an actionsheet is open while the user is allowed to interact with the rest of the app.