### PR TITLE
fix: tailwindcss/plugin import

### DIFF
--- a/packages/nativewind/utils/tailwind-plugin/index.js
+++ b/packages/nativewind/utils/tailwind-plugin/index.js
@@ -1,4 +1,5 @@
-const plugin = require('tailwindcss/plugin');
+import plugin from 'tailwindcss/plugin';
+
 const stateObj = {
   'indeterminate=true': 1,
   'indeterminate=false': 1,

--- a/packages/nativewind/utils/tailwind-plugin/index.ts
+++ b/packages/nativewind/utils/tailwind-plugin/index.ts
@@ -1,4 +1,4 @@
-const plugin = require('tailwindcss/plugin');
+import plugin from 'tailwindcss/plugin';
 
 const stateObj = {
   'indeterminate=true': 1,


### PR DESCRIPTION
fixed the import of `tailwindcss/plugin` in `gluestack-ui/nativewind-utils`.
