### PR TITLE
feat: support custom tailwind config for `tva` + docs

### DIFF
--- a/example/storybook-nativewind/src/home/theme-configuration/customizing-theme/index.nw.stories.mdx
+++ b/example/storybook-nativewind/src/home/theme-configuration/customizing-theme/index.nw.stories.mdx
@@ -35,11 +35,17 @@ export const config = {
     /* Added a new background color for light mode */
     '--color-background-new': '#BAE7FC',
 
+   /* Add a new token with custom font-size */
+   '--custom-font-size': '80'
+
   }),
   dark: vars({
      ... // other tokens
       /* Added a new background color for dark mode */
     '--color-background-new': '#89D6FA',
+
+   /* Add a new token with custom font-size */
+   '--custom-font-size': '80'
   }),
 };
 
@@ -59,6 +65,11 @@ export const config = {
           new: 'var(--color-background-new)',
         },
       },
+        fontSize: {
+          ... // other font size values,
+          /* Added a new font size token */
+         'custom-heading-xl':'var(--custom-font-size)'
+      },
     },
     plugins: [],
   },
@@ -69,3 +80,26 @@ You can customize all the tokens in `config`. For a complete list of tokens and 
 By utilizing this approach, you can seamlessly modify the primary color tokens of the theme while maintaining the overall theme configuration intact.
 
 If you want to extend the default tailwind config and add fonts, breakpoints, border radius values, and more, please refer to the [tailwindcss](https://tailwindcss.com/docs/theme#customizing-the-default-theme) documentation.
+
+In order for `custom-heading-xl` to work, you also will need to pass an additional config for the [tva](https://gluestack.io/ui/docs/home/getting-started/gluestack-ui-nativewind-utils#tva-tailwind-variant-authority) function when defining a component, for [Text](https://gluestack.io/ui/docs/components/text) it will be:
+```jsx
+// Text style props are from here https://gluestack.io/ui/docs/components/text (step 3, the one from styles.tsx)
+const textStyleProps = {}
+
+//ref @see https://www.tailwind-variants.org/docs/api-reference#config-optional
+const config = {
+  twMerge: true,
+  twMergeConfig: {
+    classGroups: {
+      'font-size': [
+        {
+          text: ['custom-heading-xl'],
+        },
+      ],
+    },
+  },
+};
+
+export const textStyle = tva(...textStyleProps, config)
+```
+Another way to solve this is by setting [global tailwind-variants config](https://www.tailwind-variants.org/docs/config#global-config), but it will affect all components. Maybe it's not your case and you want to have a custom font-size only for a specific component/part of the app.

--- a/packages/nativewind/utils/tva/index.js
+++ b/packages/nativewind/utils/tva/index.js
@@ -1,27 +1,30 @@
 // @ts-ignore
 import { tv } from 'tailwind-variants';
 import { deepMergeObjects } from '../utils/deepMerge';
-const tvatemp = (options) => {
-    const parentVariants = options?.parentVariants;
-    const parentCompoundVariants = options?.parentCompoundVariants;
-    delete options.parentVariants;
-    delete options.parentCompoundVariants;
-    options.variants = deepMergeObjects(parentVariants, options.variants);
-    if (Array.isArray(parentCompoundVariants) &&
-        parentCompoundVariants.length > 0) {
-        if (!options.compoundVariants) {
-            options.compoundVariants = [];
-        }
-        options.compoundVariants = [
-            ...parentCompoundVariants,
-            ...options.compoundVariants,
-        ];
+const tvatemp = (options, config) => {
+  const parentVariants = options?.parentVariants;
+  const parentCompoundVariants = options?.parentCompoundVariants;
+  delete options.parentVariants;
+  delete options.parentCompoundVariants;
+  options.variants = deepMergeObjects(parentVariants, options.variants);
+  if (
+    Array.isArray(parentCompoundVariants) &&
+    parentCompoundVariants.length > 0
+  ) {
+    if (!options.compoundVariants) {
+      options.compoundVariants = [];
     }
-    const callback = tv(options);
-    return (inlineProps) => {
-        const { parentVariants: inlineParentVariants = {}, ...variant } = inlineProps;
-        const mergedVariants = deepMergeObjects(inlineParentVariants, variant);
-        return callback({ ...mergedVariants });
-    };
+    options.compoundVariants = [
+      ...parentCompoundVariants,
+      ...options.compoundVariants,
+    ];
+  }
+  const callback = tv(options, config);
+  return (inlineProps) => {
+    const { parentVariants: inlineParentVariants = {}, ...variant } =
+      inlineProps;
+    const mergedVariants = deepMergeObjects(inlineParentVariants, variant);
+    return callback({ ...mergedVariants });
+  };
 };
 export const tva = tvatemp;

--- a/packages/nativewind/utils/tva/index.ts
+++ b/packages/nativewind/utils/tva/index.ts
@@ -1,46 +1,53 @@
+import type { TVA } from '../types';
+import type { TVConfig } from 'tailwind-variants/dist/config';
+import { deepMergeObjects } from '../utils/deepMerge';
 // @ts-ignore
 import { tv } from 'tailwind-variants';
-import type { TVA } from '../types';
 
-import { deepMergeObjects } from '../utils/deepMerge';
-
-const tvatemp = (options: {
+const tvatemp = (
+  options: {
+    /**
+     * Extend allows for easy composition of components.
+     * @see https://www.tailwind-variants.org/docs/composing-components
+     */
+    extend?: any;
+    /**
+     * Base allows you to set a base class for a component.
+     */
+    base?: any;
+    /**
+     * Slots allow you to separate a component into multiple parts.
+     * @see https://www.tailwind-variants.org/docs/slots
+     */
+    slots?: any;
+    /**
+     * Variants allow you to create multiple versions of the same component.
+     * @see https://www.tailwind-variants.org/docs/variants#adding-variants
+     */
+    variants?: any;
+    /**
+     * Compound variants allow you to apply classes to multiple variants at once.
+     * @see https://www.tailwind-variants.org/docs/variants#compound-variants
+     */
+    compoundVariants?: any;
+    /**
+     * Compound slots allow you to apply classes to multiple slots at once.
+     */
+    compoundSlots?: any;
+    /**
+     * Default variants allow you to set default variants for a component.
+     * @see https://www.tailwind-variants.org/docs/variants#default-variants
+     */
+    defaultVariants?: any;
+    parentVariants?: any;
+    parentCompoundVariants?: any;
+  },
   /**
-   * Extend allows for easy composition of components.
-   * @see https://www.tailwind-variants.org/docs/composing-components
+   * The config object allows you to modify the default configuration.
+   * @see https://www.tailwind-variants.org/docs/api-reference#config-optional
    */
-  extend?: any;
-  /**
-   * Base allows you to set a base class for a component.
-   */
-  base?: any;
-  /**
-   * Slots allow you to separate a component into multiple parts.
-   * @see https://www.tailwind-variants.org/docs/slots
-   */
-  slots?: any;
-  /**
-   * Variants allow you to create multiple versions of the same component.
-   * @see https://www.tailwind-variants.org/docs/variants#adding-variants
-   */
-  variants?: any;
-  /**
-   * Compound variants allow you to apply classes to multiple variants at once.
-   * @see https://www.tailwind-variants.org/docs/variants#compound-variants
-   */
-  compoundVariants?: any;
-  /**
-   * Compound slots allow you to apply classes to multiple slots at once.
-   */
-  compoundSlots?: any;
-  /**
-   * Default variants allow you to set default variants for a component.
-   * @see https://www.tailwind-variants.org/docs/variants#default-variants
-   */
-  defaultVariants?: any;
-  parentVariants?: any;
-  parentCompoundVariants?: any;
-}) => {
+  config: TVConfig
+) => {
   const parentVariants = options?.parentVariants;
   const parentCompoundVariants = options?.parentCompoundVariants;
 
@@ -61,7 +68,7 @@ const tvatemp = (options: {
     ];
   }
 
-  const callback = tv(options);
+  const callback = tv(options, config);
 
   return (inlineProps: any) => {
     const { parentVariants: inlineParentVariants = {}, ...variant } =


### PR DESCRIPTION
Hi,
First of all, thanks for the library,
Now to the issue:
When defining a custom tailwind token in tailwind.config.js, it seems that [tailwind-variants](https://github.com/gluestack/gluestack-ui/blob/d475857fb64759b6f9fd5f45d3c37c02b5ba7fa7/packages/nativewind/utils/tva/index.ts#L2C21-L2C38) cannot resolve these custom tailwind tokens. For that you need to pass a [custom config](https://github.com/gluestack/gluestack-ui/blob/main/packages/nativewind/utils/tva/index.ts#L64) to the [tv](https://www.tailwind-variants.org/docs/config) function. 
Another way to solve this is by setting [global tailwind-variants config](https://www.tailwind-variants.org/docs/config#global-config). But this is not the case when you want to have different configurations in different parts of the application (e.g. one part of the application has one theme (the host application), the second has another theme (a user journey/flow which is an npm package), both use gluestack).

### Before:
<img src="https://github.com/user-attachments/assets/b457c179-5dc8-4f6d-bcd7-c93dd9ee3f1b" width="256"/>

### After:
<img src="https://github.com/user-attachments/assets/4da8d06c-f5dd-47a9-9ed5-8c707ef7ad55" width="256"/>
