### PR TITLE
Feat: Add support for React Native 0.77

### DIFF
--- a/packages/react-native-aria/interactions/src/useKeyboardDismisssable.ts
+++ b/packages/react-native-aria/interactions/src/useKeyboardDismisssable.ts
@@ -1,5 +1,6 @@
 import React from 'react';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import type { NativeEventSubscription } from 'react-native'
 import { BackHandler, Platform } from 'react-native';
 
 type IParams = {
@@ -43,6 +44,8 @@ export const useKeyboardDismissable = ({ enabled, callback }: IParams) => {
 };
 
 export function useBackHandler({ enabled, callback }: IParams) {
+  const backHandlerSubscription = useRef<NativeEventSubscription>();
+
   useEffect(() => {
     if (Platform.OS === 'web') {
       const handleEscape = (e: KeyboardEvent) => {
@@ -61,12 +64,12 @@ export function useBackHandler({ enabled, callback }: IParams) {
         return true;
       };
       if (enabled) {
-        BackHandler.addEventListener('hardwareBackPress', backHandler);
+        backHandlerSubscription.current = BackHandler.addEventListener('hardwareBackPress', backHandler);
       } else {
-        BackHandler.removeEventListener('hardwareBackPress', backHandler);
+        backHandlerSubscription.current?.remove();
       }
       return () =>
-        BackHandler.removeEventListener('hardwareBackPress', backHandler);
+        backHandlerSubscription.current?.remove();
     }
   }, [enabled, callback]);
 }


### PR DESCRIPTION
React Native 0.77 has remove `BackHandler.removeEventListener` in [#44d6194](https://github.com/facebook/react-native/commit/44d619414c1de3dbf17a421afa8dbcec7cdab025), and it causes app to crash when upgrading to version 0.77.

I updated the code with `useRef` to store subscription returned by `BackHandler.addEventListener` and replace `BackHandler.removeEventListener` with the `remove` method of the subscription.

As stated in this old commit [#2596b2f](https://github.com/facebook/react-native/commit/2596b2f6954362d2cd34a1be870810ab90cbb916). There should be `remove` method in the returned subscription in previous React Native version, so it won't affect old React Native version.

![image](https://github.com/user-attachments/assets/e67ded38-ca7f-4664-84fd-5a5d60cdcbea)
