### PR TITLE
Add license field to @gluestack-ui/* scoped packages

### DIFF
--- a/packages/unstyled/accordion/package.json
+++ b/packages/unstyled/accordion/package.json
@@ -15,7 +15,8 @@
     "ios",
     "nextjs"
   ],
-  "version": "1.0.13",
+  "version": "1.0.14",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/actionsheet/package.json
+++ b/packages/unstyled/actionsheet/package.json
@@ -15,7 +15,8 @@
     "ios",
     "nextjs"
   ],
-  "version": "0.2.51",
+  "version": "0.2.52",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/alert-dialog/package.json
+++ b/packages/unstyled/alert-dialog/package.json
@@ -15,7 +15,8 @@
     "ios",
     "nextjs"
   ],
-  "version": "0.1.37",
+  "license": "MIT",
+  "version": "0.1.38",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/alert/package.json
+++ b/packages/unstyled/alert/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/alert",
-  "version": "0.1.16",
+  "license": "MIT",
+  "version": "0.1.17",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/avatar/package.json
+++ b/packages/unstyled/avatar/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/avatar",
   "description": "A universal headless avatar component for React Native, Next.js & React",
-  "version": "0.1.18",
+  "version": "0.1.19",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/button/package.json
+++ b/packages/unstyled/button/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/button",
-  "version": "1.0.13",
+  "version": "1.0.14",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/checkbox/package.json
+++ b/packages/unstyled/checkbox/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/checkbox",
-  "version": "0.1.38",
+  "version": "0.1.39",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/divider/package.json
+++ b/packages/unstyled/divider/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/divider",
-  "version": "0.1.10",
+  "version": "0.1.11",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/fab/package.json
+++ b/packages/unstyled/fab/package.json
@@ -15,7 +15,8 @@
     "ios",
     "nextjs"
   ],
-  "version": "0.1.27",
+  "version": "0.1.28",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/form-control/package.json
+++ b/packages/unstyled/form-control/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/form-control",
   "description": "A universal headless form-control component for React Native, Next.js & React",
-  "version": "0.1.19",
+  "version": "0.1.20",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/hooks/package.json
+++ b/packages/unstyled/hooks/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/hooks",
   "description": "Provides hooks used in gluestack-ui",
-  "version": "0.1.13",
+  "version": "0.1.14",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/hstack/package.json
+++ b/packages/unstyled/hstack/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/hstack",
   "description": "A universal headless hstack component for React Native, Next.js & React",
-  "version": "0.1.17",
+  "version": "0.1.18",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/icon/package.json
+++ b/packages/unstyled/icon/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/icon",
   "description": "A universal headless icon component for React Native, Next.js & React",
-  "version": "0.1.25",
+  "version": "0.1.26",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/image-viewer/package.json
+++ b/packages/unstyled/image-viewer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/image-viewer",
-  "version": "0.0.16",
+  "version": "0.0.17",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/image/package.json
+++ b/packages/unstyled/image/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/image",
-  "version": "0.1.16",
+  "version": "0.1.17",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/input/package.json
+++ b/packages/unstyled/input/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/input",
   "description": "A universal headless input component for React Native, Next.js & React",
-  "version": "0.1.37",
+  "version": "0.1.38",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/linear-gradient/package.json
+++ b/packages/unstyled/linear-gradient/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/linear-gradient",
-  "version": "0.1.3",
+  "version": "0.1.4",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/link/package.json
+++ b/packages/unstyled/link/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/link",
-  "version": "0.1.28",
+  "version": "0.1.29",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/menu/package.json
+++ b/packages/unstyled/menu/package.json
@@ -15,7 +15,8 @@
     "ios",
     "nextjs"
   ],
-  "version": "0.2.42",
+  "version": "0.2.43",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/modal/package.json
+++ b/packages/unstyled/modal/package.json
@@ -15,7 +15,8 @@
     "ios",
     "nextjs"
   ],
-  "version": "0.1.40",
+  "version": "0.1.41",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/overlay/package.json
+++ b/packages/unstyled/overlay/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/overlay",
   "description": "A universal headless overlay component for React Native, Next.js & React",
-  "version": "0.1.21",
+  "version": "0.1.22",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/pin-input/package.json
+++ b/packages/unstyled/pin-input/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/pin-input",
   "description": "A universal headless pin-input component for React Native, Next.js & React",
-  "version": "0.0.13",
+  "version": "0.0.14",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/popover/package.json
+++ b/packages/unstyled/popover/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/popover",
-  "version": "0.1.48",
+  "version": "0.1.49",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/pressable/package.json
+++ b/packages/unstyled/pressable/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/pressable",
-  "version": "0.1.22",
+  "version": "0.1.23",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/progress/package.json
+++ b/packages/unstyled/progress/package.json
@@ -15,7 +15,8 @@
     "ios",
     "nextjs"
   ],
-  "version": "0.1.18",
+  "version": "0.1.19",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/provider/package.json
+++ b/packages/unstyled/provider/package.json
@@ -15,7 +15,8 @@
     "ios",
     "nextjs"
   ],
-  "version": "0.1.18",
+  "version": "0.1.19",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/radio/package.json
+++ b/packages/unstyled/radio/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/radio",
-  "version": "0.1.39",
+  "version": "0.1.40",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/react-native-aria/package.json
+++ b/packages/unstyled/react-native-aria/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/react-native-aria",
-  "version": "0.1.7",
+  "version": "0.1.8",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/select/package.json
+++ b/packages/unstyled/select/package.json
@@ -15,7 +15,8 @@
     "ios",
     "nextjs"
   ],
-  "version": "0.1.31",
+  "version": "0.1.32",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/slider/package.json
+++ b/packages/unstyled/slider/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/slider",
   "description": "A universal headless slider component for React Native, Next.js & React",
-  "version": "0.1.31",
+  "version": "0.1.32",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/spinner/package.json
+++ b/packages/unstyled/spinner/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/spinner",
-  "version": "0.1.15",
+  "version": "0.1.16",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/stack/package.json
+++ b/packages/unstyled/stack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/stack",
-  "version": "0.1.5",
+  "version": "0.1.6",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/switch/package.json
+++ b/packages/unstyled/switch/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/switch",
-  "version": "0.1.28",
+  "version": "0.1.29",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/tabs/package.json
+++ b/packages/unstyled/tabs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gluestack-ui/tabs",
-  "version": "0.1.23",
+  "version": "0.1.24",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/textarea/package.json
+++ b/packages/unstyled/textarea/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/textarea",
   "description": "A universal headless text-area component for React Native, Next.js & React",
-  "version": "0.1.24",
+  "version": "0.1.25",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/toast/package.json
+++ b/packages/unstyled/toast/package.json
@@ -15,7 +15,8 @@
     "ios",
     "nextjs"
   ],
-  "version": "1.0.9",
+  "version": "1.0.10",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/transitions/package.json
+++ b/packages/unstyled/transitions/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/transitions",
   "description": "Transitions animations for React Native, Next.js & React",
-  "version": "0.1.11",
+  "version": "0.1.12",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/utils/package.json
+++ b/packages/unstyled/utils/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/utils",
   "description": "Utility functions used internally in gluestack-ui",
-  "version": "0.1.15",
+  "version": "0.1.16",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",

--- a/packages/unstyled/vstack/package.json
+++ b/packages/unstyled/vstack/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@gluestack-ui/vstack",
   "description": "A universal headless vstack component for React Native, Next.js & React",
-  "version": "0.1.16",
+  "version": "0.1.17",
+  "license": "MIT",
   "main": "lib/index",
   "module": "lib/index",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
The license field wasn't being published in the newer @gluestack-ui/* scoped packages on NPM. Example with [@gluestack-ui/overlay](https://www.npmjs.com/package/@gluestack-ui/overlay), where the license field shows as "none".

I assume the license to be applied to these packages would be the same as the code in the rest of the repo, which is currently set to MIT license. I copied this attribute to all the packages manually, and bumped the version so it can be published and consumed by others upstream.

Adding the correct license is a requirement the CI tool I am working out of right now. I hope if the MIT license isn't the correct license for these packages, I can at least get the discussion going around the topic here.