### PR TITLE
Add css interop for bottom sheet style props

### DIFF
--- a/example/storybook-nativewind/src/core-components/nativewind/bottomsheet/index.tsx
+++ b/example/storybook-nativewind/src/core-components/nativewind/bottomsheet/index.tsx
@@ -100,7 +100,12 @@ export const BottomSheetPortal = ({
   handleComponent: DragIndicator,
   backdropComponent: BackDrop,
   ...props
-}: Partial<IBottomSheetProps> & {
+}: Partial<IBottomSheetProps & {
+    handleClassName: string
+    containerClassName: string
+    backgroundClassName: string
+    handleIndicatorClassName: string
+  }> & {
   defaultIsOpen?: boolean;
   snapToIndex?: number;
   snapPoints: string[];
@@ -288,6 +293,13 @@ export const BottomSheetFlatList = GorhomBottomSheetFlatList;
 export const BottomSheetSectionList = GorhomBottomSheetSectionList;
 export const BottomSheetTextInput = GorhomBottomSheetInput;
 
+cssInterop(GorhomBottomSheet, {
+  className: 'style',
+  handleClassName: 'handleStyle',
+  containerClassName: 'containerStyle',
+  backgroundClassName: 'backgroundStyle',
+  handleIndicatorClassName: 'handleIndicatorStyle',
+})
 cssInterop(GorhomBottomSheetInput, { className: 'style' });
 cssInterop(GorhomBottomSheetScrollView, { className: 'style' });
 cssInterop(GorhomBottomSheetFlatList, { className: 'style' });


### PR DESCRIPTION
Small change to support class names on some key properties. Huge fan of this bottom sheet integration so far. It is able to better handle my complex use cases to that of the action sheet. Thanks!