### PR TITLE
Refactor GridItem flexBasisValue calculation logic

### DIFF
--- a/example/storybook-nativewind/src/core-components/nativewind/grid/index.tsx
+++ b/example/storybook-nativewind/src/core-components/nativewind/grid/index.tsx
@@ -251,10 +251,6 @@ type IGridItemProps = ViewProps &
 
 const GridItem = forwardRef<React.ComponentRef<typeof View>, IGridItemProps>(
   function GridItem({ className, _extra, ...props }, ref) {
-    const [flexBasisValue, setFlexBasisValue] = useState<
-      number | string | null
-    >('auto');
-
     const {
       calculatedWidth,
       numColumns,
@@ -269,7 +265,7 @@ const GridItem = forwardRef<React.ComponentRef<typeof View>, IGridItemProps>(
       generateResponsiveColSpans({ gridItemClassName: gridItemClass })
     ) ?? 1) as number;
 
-    useEffect(() => {
+    const flexBasisValue = useMemo(() => {
       if (
         !flexDirection?.includes('column') &&
         calculatedWidth &&
@@ -291,18 +287,17 @@ const GridItem = forwardRef<React.ComponentRef<typeof View>, IGridItemProps>(
             ? 2
             : rowColsCount - 1);
 
-        const flexBasisVal =
+        return (
           Math.min(
             (((calculatedWidth - gutterOffset) * responsiveColSpan) /
               numColumns /
               calculatedWidth) *
-              100,
-            100
-          ) + '%';
-
-        setFlexBasisValue(flexBasisVal);
+            100,
+            100,
+          ) + '%'
+        );
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+      return 'auto';
     }, [
       calculatedWidth,
       responsiveColSpan,
@@ -310,6 +305,8 @@ const GridItem = forwardRef<React.ComponentRef<typeof View>, IGridItemProps>(
       columnGap,
       gap,
       flexDirection,
+      itemsPerRow,
+      props?.index,
     ]);
 
     return (


### PR DESCRIPTION
The current logic that determines the flexBasis uses state but this was causing issues for me a lot of other users, this PR leverages useMemo to cache the flexBasis

Closes #2794 & #2782 

| Before | After |
|--------|--------|
| ![Screenshot 2025-05-01 at 7 43 00 AM](https://github.com/user-attachments/assets/805d3149-6a81-4122-be59-07dfe0f6685e) | ![Screenshot 2025-05-01 at 7 43 39 AM](https://github.com/user-attachments/assets/f8e08627-1ec4-4e4b-90e6-fdecb6cefd2c) | 