### PR TITLE
fix(nativewind-utils): correct TVConfig import

### DIFF
--- a/packages/nativewind/utils/tva/index.ts
+++ b/packages/nativewind/utils/tva/index.ts
@@ -1,5 +1,5 @@
 import type { TVA } from '../types';
-import type { TVConfig } from 'tailwind-variants/dist/config';
+import type { TVConfig } from 'tailwind-variants/dist/config.d.ts';
 import { deepMergeObjects } from '../utils/deepMerge';
 // @ts-ignore
 import { tv } from 'tailwind-variants';


### PR DESCRIPTION
Hey, just encountered that in my application, wanted to add a CI job that checks "type-correctness" via `tsc --noEmit` and turns out there's an import in the lib, that makes this impossible if you use `tva` (which I am). Hope this helps, thanks.

Fixes the following:
```
./node_modules/.bin/tsc --noEmit
node_modules/@gluestack-ui/nativewind-utils/tva/index.ts:2:31 - error TS2307: Cannot find module 'tailwind-variants/dist/config' or its corresponding type declarations.

2 import type { TVConfig } from 'tailwind-variants/dist/config';
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Happens on:
```
"expo": "53.0.9"
"typescript": "5.8.3"
"@gluestack-ui/nativewind-utils": "1.0.26"
```
