### PR TITLE
Fix broken link to NativeWind installation docs

### DIFF
--- a/example/storybook-nativewind/src/home/getting-started/Installation/index.nw.stories.mdx
+++ b/example/storybook-nativewind/src/home/getting-started/Installation/index.nw.stories.mdx
@@ -146,7 +146,7 @@ If you encounter issues during the CLI installation, refer to the manual install
 
 ### Step 1: Setup your project.
 
-Setup nativewind in your project following [NativeWind documentation](https://www.nativewind.dev/getting-started/react-native).
+Setup nativewind in your project following [NativeWind documentation](https://www.nativewind.dev/docs/getting-started/installation).
 
 ### Step 2: Install dependencies
 


### PR DESCRIPTION
Old link was: https://www.nativewind.dev/getting-started/react-native which is broken. Correct link is: https://www.nativewind.dev/docs/getting-started/installation