### PR TITLE
chore: update package versions to 1.0.45

### DIFF
--- a/.changeset/many-hoops-arrive.md
+++ b/.changeset/many-hoops-arrive.md
@@ -1,5 +1,0 @@
----
-'@gluestack-nightly/ui-next-adapter': patch
----
-
-chore: test

--- a/packages/ui-next-adapter/CHANGELOG.md
+++ b/packages/ui-next-adapter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gluestack-nightly/ui-next-adapter
 
+## 1.0.45
+
+### Patch Changes
+
+- 21f5064: chore: test
+
 ## 1.0.41
 
 ### Patch Changes

--- a/packages/ui-next-adapter/package.json
+++ b/packages/ui-next-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gluestack-nightly/ui-next-adapter",
   "author": "gluestack",
-  "version": "1.0.44",
+  "version": "1.0.47",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## 📦 Package Version Updates
    
    This PR updates package versions in consuming projects to use the newly published packages.
    
    **Published packages:**
     @gluestack-nightly/ui-next-adapter@1.0.47
    
    **New version:** `1.0.45`
    
    > ⚠️ **Do not auto-merge this PR** - Review the changes before merging.
    > This PR was created automatically by the GitHub Actions workflow.
    