### PR TITLE
chore: update package versions to 1.0.48

### DIFF
--- a/.changeset/blue-cars-repeat.md
+++ b/.changeset/blue-cars-repeat.md
@@ -1,5 +1,0 @@
----
-'@gluestack-nightly/ui-next-adapter': patch
----
-
-fix: updated turbopack config

--- a/.changeset/fifty-books-try.md
+++ b/.changeset/fifty-books-try.md
@@ -1,5 +1,0 @@
----
-'@gluestack-nightly/ui-next-adapter': patch
----
-
-feat: addded support for turbopack

--- a/packages/ui-next-adapter/CHANGELOG.md
+++ b/packages/ui-next-adapter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @gluestack-nightly/ui-next-adapter
 
+## 1.0.48
+
+### Patch Changes
+
+- bb5c274: fix: updated turbopack config
+- 5b23a71: feat: addded support for turbopack
+
 ## 1.0.45
 
 ### Patch Changes

--- a/packages/ui-next-adapter/package.json
+++ b/packages/ui-next-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gluestack-nightly/ui-next-adapter",
   "author": "gluestack",
-  "version": "1.0.47",
+  "version": "1.0.49",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## 📦 Package Version Updates
    
    This PR updates package versions in consuming projects to use the newly published packages.
    
    **Published packages:**
     @gluestack-nightly/ui-next-adapter@1.0.49
    
    **New version:** `1.0.48`
    
    > ⚠️ **Do not auto-merge this PR** - Review the changes before merging.
    > This PR was created automatically by the GitHub Actions workflow.
    