### PR TITLE
chore: update package versions to 3.0.0-alpha.5

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -10,6 +10,7 @@
   },
   "changesets": [
     "beige-lights-shop",
+    "green-rockets-cry",
     "stale-news-wave"
   ]
 }

--- a/packages/gluestack-core/CHANGELOG.md
+++ b/packages/gluestack-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @gluestack-ui/core
 
+## 3.0.0-alpha.5
+
+### Patch Changes
+
+- 3f65e0b: chore: test
+
 ## 3.0.0-alpha.4
 
 ### Patch Changes

--- a/packages/gluestack-core/package.json
+++ b/packages/gluestack-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gluestack-ui/core",
   "description": "Universal UI components for React Native, Expo, and Next.js",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "main": "./lib/esm/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/esm/index.d.ts",


### PR DESCRIPTION
## 📦 Package Version Updates
    
    This PR updates package versions in consuming projects to use the newly published packages.
    
    **Published packages:**
     @gluestack-ui/core@3.0.0-alpha.5
    
    **New version:** `3.0.0-alpha.5`
    
    > ⚠️ **Do not auto-merge this PR** - Review the changes before merging.
    > This PR was created automatically by the GitHub Actions workflow.
    