### PR TITLE
fix(nativewind-utils): access tvconfig in an alternate way

### DIFF
--- a/packages/nativewind/utils/tva/index.js
+++ b/packages/nativewind/utils/tva/index.js
@@ -1,5 +1,4 @@
 import { deepMergeObjects } from '../utils/deepMerge';
-// @ts-ignore
 import { tv } from 'tailwind-variants';
 const tvatemp = (
   options,

--- a/packages/nativewind/utils/tva/index.ts
+++ b/packages/nativewind/utils/tva/index.ts
@@ -1,8 +1,8 @@
 import type { TVA } from '../types';
-import type { TVConfig } from 'tailwind-variants/dist/config';
 import { deepMergeObjects } from '../utils/deepMerge';
-// @ts-ignore
-import { tv } from 'tailwind-variants';
+import { tv, defaultConfig } from 'tailwind-variants';
+
+type TVConfig = typeof defaultConfig;
 
 const tvatemp = (
   options: {


### PR DESCRIPTION
The previous approach for accessing TVConfig was not working because it wasn't actually module-valid code. It was reaching into a private file in the tailwind-variants package. This works around that issue by fetching a variable with the type TVConfig and using `typeof` to extract the type.

(Also runs `yarn workspace @gluestack-ui/nativewind-utils build` which clearly picked up some source code changes which hadn't been built yet)