### PR TITLE
fix(accordion): prevent animation on initial render

### DIFF
--- a/packages/gluestack-core/src/accordion/creator/AnimatedHeight.tsx
+++ b/packages/gluestack-core/src/accordion/creator/AnimatedHeight.tsx
@@ -2,11 +2,10 @@ import React, { useRef, useEffect, useState } from 'react';
 import { Animated, StyleSheet } from 'react-native';
 
 const AnimatedHeight = ({ hide, extraHeight = 0, children }: any) => {
-  const [measuredHeight, setMeasuredHeight] = useState(0);
+  const [measuredHeight, setMeasuredHeight] = useState(hide ? 0 : null);
   const opacityValue = useRef(new Animated.Value(hide ? 0 : 1)).current;
-  const heightValue = useRef(
-    new Animated.Value(hide ? 0 : measuredHeight + extraHeight)
-  ).current;
+  const heightValue = useRef(new Animated.Value(hide ? 0 : 1)).current;
+  const animate = hide || measuredHeight !== null;
 
   useEffect(() => {
     Animated.timing(opacityValue, {
@@ -20,30 +19,38 @@ const AnimatedHeight = ({ hide, extraHeight = 0, children }: any) => {
       duration: 200,
       useNativeDriver: false,
     }).start();
-  }, [hide, measuredHeight, extraHeight, heightValue, opacityValue]);
+  }, [hide, heightValue, opacityValue]);
 
   const animatedHeight = heightValue.interpolate({
     inputRange: [0, 1],
-    outputRange: [0, measuredHeight + extraHeight],
+    outputRange: [0, (measuredHeight ?? 0) + extraHeight],
   });
 
   return (
     <Animated.View
-      style={[
-        styles.hidden,
-        {
-          height: animatedHeight,
-        },
-      ]}
+      style={
+        animate
+          ? [
+              styles.hidden,
+              {
+                height: animatedHeight,
+              },
+            ]
+          : undefined
+      }
     >
       <Animated.View
-        style={[
-          StyleSheet.absoluteFill,
-          styles.autoBottom,
-          {
-            opacity: opacityValue,
-          },
-        ]}
+        style={
+          animate
+            ? [
+                StyleSheet.absoluteFill,
+                styles.autoBottom,
+                {
+                  opacity: opacityValue,
+                },
+              ]
+            : undefined
+        }
         onLayout={(e) => {
           const height = Math.round(e.nativeEvent.layout.height);
           setMeasuredHeight(height);


### PR DESCRIPTION
## Description

This PR fixes an issue where accordion items would animate on initial page load, causing an undesirable visual effect where expanded accordions would animate from closed to open state when the page first renders.

## Problem

When an accordion component mounts with items already expanded (e.g., via `defaultValue` or `value` props), the `AnimatedHeight` component would trigger animations even on the initial render. This caused:
- Visual glitch where content animates from height 0 to full height on page load
- Content shift as accordions expand
- Poor user experience on initial page load

## Solution

The fix modifies the `AnimatedHeight` component to:
1. Initialize `measuredHeight` state to `null` for initially expanded items (instead of `0`)
2. Only apply height constraints after content has been measured OR when the item is hidden
3. Use an `animate` flag to conditionally apply animated styles

### Key changes:
- `measuredHeight` starts as `null` for expanded items, `0` for hidden items
- Added `animate` flag: `const animate = hide || measuredHeight !== null`
- Styles are only applied when `animate` is true
- This allows initially expanded items to render at their natural height until measured

## Testing

Tested with accordions that have:
- `defaultValue` set to expand certain items on mount
- `value` prop to control expanded state
- Both collapsed and expanded initial states

## Before/After

**Before:** Accordions visibly animate from closed to open on initial page load
**After:** Accordions render immediately in their correct state without animation

## Breaking Changes

None - this is a backward-compatible fix that only affects the initial mount behavior.