### PR TITLE
Mention active pseudo class for Pressable component

### DIFF
--- a/src/components/ui/pressable/docs/index.mdx
+++ b/src/components/ui/pressable/docs/index.mdx
@@ -108,6 +108,15 @@ Component receives states as props as boolean values, which are applied as `data
           <InlineCode>true | false</InlineCode>
         </TableCell>
       </TableRow>
+      <TableRow>
+        <TableCell>
+          <InlineCode>active</InlineCode>
+        </TableCell>
+        <TableCell>data-active</TableCell>
+        <TableCell>
+          <InlineCode>true | false</InlineCode>
+        </TableCell>
+      </TableRow>
     </TableBody>
   </Table>
 </>


### PR DESCRIPTION
Add mention of the active: pseudo class which allows for pressed state styling of Pressable components