### PR TITLE
Document platform support for Toast component

### DIFF
--- a/src/components/ui/toast/docs/index.mdx
+++ b/src/components/ui/toast/docs/index.mdx
@@ -30,6 +30,10 @@ This is an illustration of **Toast** component.
 
 /// {Example:basic} ///
 
+### Platform Support
+
+**The Tooltip component is currently only supported on web platform**. Native mobile support (iOS/Android) is not available at this time. For more information, see [issue #1555](https://github.com/gluestack/gluestack-ui/issues/1555#issuecomment-1876602492).
+
 <br />
 
 ## Installation


### PR DESCRIPTION
I've used Tooltip in my app, but then I had troubles with making it work on native.

Only after searching through issues of this repo, I've found out that it just doesn't work on native at all.

Let's improve docs on that, so others don't fall into the same mistake.