### PR TITLE
fix(badge): make action, variant and size reactive to state changes

### DIFF
--- a/apps/starter-kit-next/components/ui/badge/index.tsx
+++ b/apps/starter-kit-next/components/ui/badge/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Text, View } from 'react-native';
 import { PrimitiveIcon, UIIcon } from '@gluestack-ui/core/icon/creator';
 import { tva } from '@gluestack-ui/utils/nativewind-utils';
@@ -120,15 +120,17 @@ function Badge({
   className,
   ...props
 }: { className?: string } & IBadgeProps) {
+
+  const contextValue = useMemo(
+    () => ({ action, variant, size }),
+    [action, variant, size]
+  );
+
   return (
     <ContextView
       className={badgeStyle({ action, variant, class: className })}
       {...props}
-      context={{
-        action,
-        variant,
-        size,
-      }}
+      context={contextValue}
     >
       {children}
     </ContextView>


### PR DESCRIPTION
This PR fixes an issue where the Badge component did not update its style when the action, variant, or size props were changed dynamically through React state.

The problem was caused by the internal style context not re-rendering when these props changed.

This update ensures that the Badge and its children (BadgeText, BadgeIcon) now react properly to prop and state updates — without needing the key workaround.