### PR TITLE
feat(gluestack-utils): export TVA and TVReturnType

### DIFF
--- a/packages/gluestack-utils/src/nativewind-utils/index.ts
+++ b/packages/gluestack-utils/src/nativewind-utils/index.ts
@@ -1,6 +1,6 @@
 export { tva } from './tva';
 export { cn } from './cn';
-export type { VariantProps } from './types';
+export type { TVA, TVReturnType, VariantProps } from './types';
 export { withStyleContext, useStyleContext } from './withStyleContext';
 export { isWeb } from './IsWeb';
 export { flush, setFlushStyles } from './flush';


### PR DESCRIPTION
Hello !

I am writting this request to export TVA types to fix downstream TypeScript issues.

- Re-export TVA and TVReturnType from nativewind-utils/index.ts so library consumers can import these types again (restoring v2 behavior and resolving missing-type errors when exporting components).
- Point the tailwind-variants config import to dist/config.d.ts to align with the dependency’s typings.

Testing: not run (type-only changes).

Have a nice day !