### PR TITLE
fix(menu): pass state object to trigger function

### DIFF
--- a/packages/gluestack-core/src/menu/creator/Menu.tsx
+++ b/packages/gluestack-core/src/menu/creator/Menu.tsx
@@ -76,11 +76,14 @@ export const Menu = ({
       );
 
       const updatedTrigger = () => {
-        return trigger({
-          ...menuTriggerProps,
-          onPress: handleOpen,
-          ref: triggerRef,
-        });
+        return trigger(
+          {
+            ...menuTriggerProps,
+            onPress: handleOpen,
+            ref: triggerRef,
+          },
+          { open: state.isOpen }
+        );
       };
 
       if (_experimentalOverlay) {


### PR DESCRIPTION
## Summary

The Menu component's trigger function signature declares a second argument `state: { open: boolean }` (see `types.ts`), but the implementation never actually passed it. This caused the trigger to always receive `undefined` for the state argument.

**The fix:** Add `{ open: state.isOpen }` as the second argument to the trigger call in `updatedTrigger()`.

## Problem

When using the Menu component with a trigger that needs to display different UI based on whether the menu is open or closed, the `state.open` property was always `undefined`:

```tsx
<Menu
  trigger={(props, state) => (
    <Button {...props}>
      {/* state.open is always undefined - BUG */}
      {state?.open ? 'Close' : 'Open'}
    </Button>
  )}
  items={items}
/>
```

## Root Cause

In `packages/gluestack-core/src/menu/creator/Menu.tsx`, the `updatedTrigger` function only passed the props object:

```tsx
// Before (bug)
const updatedTrigger = () => {
  return trigger({
    ...menuTriggerProps,
    onPress: handleOpen,
    ref: triggerRef,
  });
};
```

## Fix

Pass the state object as the second argument to match the declared type signature:

```tsx
// After (fix)
const updatedTrigger = () => {
  return trigger(
    {
      ...menuTriggerProps,
      onPress: handleOpen,
      ref: triggerRef,
    },
    { open: state.isOpen }
  );
};
```

## Test Plan

- [x] Verified fix with unit tests that check `state.open` is `true` when menu is open and `false` when closed
- [x] Tested that state is preserved correctly across parent re-renders caused by async data

🤖 Generated with [Claude Code](https://claude.com/claude-code)