### PR TITLE
Add generic types to useBreakpointValue hook

### DIFF
--- a/packages/gluestack-utils/src/hooks/use-break-point-value/index.ts
+++ b/packages/gluestack-utils/src/hooks/use-break-point-value/index.ts
@@ -28,10 +28,10 @@ Object.entries(screenSize).forEach(([key, value]) => {
   }
 });
 
-export const getBreakPointValue = (
-  values: BreakPointValue,
+export const getBreakPointValue = <const V extends BreakPointValue>(
+  values: V,
   width: number
-): unknown => {
+): V[keyof V] => {
   if (typeof values !== 'object') return values;
 
   let finalBreakPointResolvedValue: unknown;
@@ -73,15 +73,17 @@ export const getBreakPointValue = (
   } else {
     finalBreakPointResolvedValue = lastValidObject.value;
   }
-  return finalBreakPointResolvedValue;
+  return finalBreakPointResolvedValue as V[keyof V];
 };
 
-export function useBreakpointValue(values: BreakPointValue): unknown {
+export function useBreakpointValue<const V extends BreakPointValue>(
+  values: V
+): V[keyof V] {
   const { width } = useWindowDimensions();
 
-  const [currentBreakPointValue, setCurrentBreakPointValue] = useState<unknown>(
-    getBreakPointValue(values, width)
-  );
+  const [currentBreakPointValue, setCurrentBreakPointValue] = useState<
+    V[keyof V]
+  >(getBreakPointValue(values, width));
 
   useEffect(() => {
     if (typeof values === 'object') {


### PR DESCRIPTION
Introduces a generic type for the useBreakpointValue hook so users of the hook don't need to deal with `unknown` in their code.

Uses a `const` generic so that styles, e.g. `{ display: "none" }` don't get typed as `Record<string, string>` and therefore cause a type error when used in a component that expects a more specific type.

I think this is a non-breaking change as users would already have had to cast the `unknown` return value if they wanted it to be typed.