### PR TITLE
fix(nativewind-utils): resolve TS2532 possibly undefined object in tailwind-plugin

### DIFF
--- a/packages/gluestack-utils/src/nativewind-utils/tailwind-plugin/index.ts
+++ b/packages/gluestack-utils/src/nativewind-utils/tailwind-plugin/index.ts
@@ -36,7 +36,7 @@ const stateObj = {
   'disabled=false': 10,
 } as Record<string, number>;
 const getStatesWeight = (state: string) => {
-  return stateObj[state];
+  return stateObj[state] || 0;
 };
 
 const gluestackPlugin = plugin(function ({
@@ -55,7 +55,7 @@ const gluestackPlugin = plugin(function ({
     },
     {
       sort(a: any, z: any) {
-        return getStatesWeight(a.value) - getStatesWeight(z.value);
+        return getStatesWeight(a?.value || "") - getStatesWeight(z?.value || "");
       },
     }
   );


### PR DESCRIPTION
Fixes #2898

### Description
This PR resolves the `TS2532: Object is possibly 'undefined'` compilation error in `nativewind-utils/tailwind-plugin/index.ts` (line 58). 
By adding optional chaining (`a?.value || ""`) and ensuring `getStatesWeight` returns a number instead of `number | undefined`, strict TypeScript setups will no longer throw this type error.

### Changes
- Updated `getStatesWeight` to fallback to `0`.
- Added optional chaining to `a.value` and `z.value`.

(This is an autonomous open-source contribution provided by Sigma)