### PR TITLE
Update SelectInput documentation with Android note

### DIFF
--- a/src/components/ui/select/docs/index.mdx
+++ b/src/components/ui/select/docs/index.mdx
@@ -245,6 +245,8 @@ It inherits all the properties of React Native's [Pressable](https://reactnative
 
 It inherits all the properties of React Native's [TextInput](https://reactnative.dev/docs/textInput) component.
 
+> Note: On Android you may need to specify a height to ensure visibility e.g. `className="h-12"` [Issue 2730](https://github.com/gluestack/gluestack-ui/issues/2730)
+
 #### SelectIcon
 
 It inherits all the properties of React Native's [Pressable](https://reactnative.dev/docs/pressable) component.


### PR DESCRIPTION
Added note about height requirement for visibility on Android. As noted in [Issue 2730](https://github.com/gluestack/gluestack-ui/issues/2730)