### PR TITLE
docs: update v5 docs to use latest CLI and stable gluestack packages

### DIFF
--- a/apps/website/app/ui/docs/guides/more/upgrade-to-v5/index.mdx
+++ b/apps/website/app/ui/docs/guides/more/upgrade-to-v5/index.mdx
@@ -1,4 +1,4 @@
-import { CodeBlock } from "@/components/custom/markdown/code-block"; 
+import { CodeBlock } from "@/components/custom/markdown/code-block";
 
 import {
   Table,
@@ -22,7 +22,7 @@ Both engines eliminate `tailwind.config.js` in favor of defining theme tokens di
 
 ## Automated Upgrade (Recommended)
 
-<CodeBlock code="npx gluestack-ui@alpha upgrade" language="bash" />
+<CodeBlock code="npx gluestack-ui@latest upgrade" language="bash" />
 
 The CLI auto-detects your current version and asks which engine to upgrade to:
 
@@ -58,7 +58,7 @@ The CLI auto-detects your current version and asks which engine to upgrade to:
     <TableRow>
       <TableCell>NativeWind version</TableCell>
       <TableCell><InlineCode>nativewind@^4.1.23</InlineCode></TableCell>
-      <TableCell><InlineCode>nativewind@^5.0.0-preview.2</InlineCode></TableCell>
+      <TableCell><InlineCode>nativewind@^5.0.0-preview.4</InlineCode></TableCell>
     </TableRow>
     <TableRow>
       <TableCell>New package</TableCell>
@@ -95,12 +95,12 @@ The CLI auto-detects your current version and asks which engine to upgrade to:
 
 ## Automated CLI Upgrade
 
-<CodeBlock code="npx gluestack-ui@alpha upgrade" language="bash" />
+<CodeBlock code="npx gluestack-ui@latest upgrade" language="bash" />
 
 Select **NativeWind v5 (Tailwind CSS v4)**. The CLI will:
 
 1. Pin `lightningcss@1.30.1` in `package.json` overrides/resolutions
-2. Replace `nativewind@^4.x` with `nativewind@^5.0.0-preview.2`, add `react-native-css`
+2. Replace `nativewind@^4.x` with `nativewind@^5.0.0-preview.4`, add `react-native-css`
 3. Upgrade `tailwindcss` to v4, add `@tailwindcss/postcss`
 4. Rewrite `global.css` with Tailwind v4 imports and theme tokens
 5. Create `postcss.config.js`
@@ -110,7 +110,7 @@ Select **NativeWind v5 (Tailwind CSS v4)**. The CLI will:
 
 > **After upgrading:** Commit your changes, then re-add components to get NativeWind v5 versions:
 > ```bash
-> npx gluestack-ui@alpha add button accordion modal # all components you use
+> npx gluestack-ui@latest add button accordion modal # all components you use
 > ```
 
 ## Manual Migration to NativeWind v5
@@ -130,11 +130,11 @@ Add to `package.json` **before** installing other packages:
 
 <Tabs>
 <TabItem label="npm">
-<CodeBlock code={`npm install nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0
+<CodeBlock code={`npm install nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6
 npm install --save-dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0`} language="bash" />
 </TabItem>
 <TabItem label="yarn">
-<CodeBlock code={`yarn add nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0
+<CodeBlock code={`yarn add nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6
 yarn add --dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0`} language="bash" />
 </TabItem>
 </Tabs>
@@ -291,7 +291,7 @@ Tailwind v4 is CSS-first — `tailwind.config.js` is no longer needed. Before de
 ### Step 8: Re-add components
 
 ```bash
-npx gluestack-ui@alpha add button accordion modal # all components you use
+npx gluestack-ui@latest add button accordion modal # all components you use
 ```
 
 When prompted to overwrite, select **Yes** to get NativeWind v5 versions.
@@ -350,7 +350,7 @@ UniWind is an Expo-only Tailwind v4 styling engine. It processes styles natively
 
 ## Automated CLI Upgrade
 
-<CodeBlock code="npx gluestack-ui@alpha upgrade" language="bash" />
+<CodeBlock code="npx gluestack-ui@latest upgrade" language="bash" />
 
 Select **UniWind (Tailwind CSS v4, Expo-only)**. The CLI will:
 
@@ -363,7 +363,7 @@ Select **UniWind (Tailwind CSS v4, Expo-only)**. The CLI will:
 
 > **After upgrading:** Commit your changes, then re-add components:
 > ```bash
-> npx gluestack-ui@alpha add button accordion modal # all components you use
+> npx gluestack-ui@latest add button accordion modal # all components you use
 > ```
 
 ## Manual Migration to UniWind
@@ -372,12 +372,12 @@ Select **UniWind (Tailwind CSS v4, Expo-only)**. The CLI will:
 
 <Tabs>
 <TabItem label="npm">
-<CodeBlock code={`npm install uniwind@^1.3.0 @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0
+<CodeBlock code={`npm install uniwind@^1.3.0 @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6
 npm install --save-dev tailwindcss@^4.1.18
 npm uninstall nativewind`} language="bash" />
 </TabItem>
 <TabItem label="yarn">
-<CodeBlock code={`yarn add uniwind@^1.3.0 @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0
+<CodeBlock code={`yarn add uniwind@^1.3.0 @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6
 yarn add --dev tailwindcss@^4.1.18
 yarn remove nativewind`} language="bash" />
 </TabItem>
@@ -546,7 +546,7 @@ Tailwind v4 is CSS-first — `tailwind.config.js` is not used by UniWind. Migrat
 ### Step 7: Re-add components
 
 ```bash
-npx gluestack-ui@alpha add button accordion modal # all components you use
+npx gluestack-ui@latest add button accordion modal # all components you use
 ```
 
 When prompted to overwrite, select **Yes** to get UniWind versions.

--- a/apps/website/app/ui/docs/home/getting-started/cli/index.mdx
+++ b/apps/website/app/ui/docs/home/getting-started/cli/index.mdx
@@ -126,7 +126,7 @@ The upgrade command auto-detects your current gluestack-ui version and presents 
 Migrates from NativeWind v4 (Tailwind v3) to NativeWind v5 (Tailwind v4). The command will automatically:
 
 1. Pin `lightningcss@1.30.1` in `package.json` overrides/resolutions
-2. Replace `nativewind@^4.x` with `nativewind@^5.0.0-preview.2` and add `react-native-css`
+2. Replace `nativewind@^4.x` with `nativewind@^5.0.0-preview.4` and add `react-native-css`
 3. Upgrade `tailwindcss` to v4 and add `@tailwindcss/postcss`
 4. Rewrite `global.css` to Tailwind v4 format (with theme tokens)
 5. Create `postcss.config.js`
@@ -134,7 +134,7 @@ Migrates from NativeWind v4 (Tailwind v3) to NativeWind v5 (Tailwind v4). The co
 7. Prompt whether to delete `tailwind.config.js` (never auto-deleted — may contain custom tokens)
 8. Create `react-native-css-env.d.ts`
 
-> **After upgrading:** Re-add your components using `npx gluestack-ui@alpha add <component>` to get the NativeWind v5 versions. Commit your changes first — re-adding will overwrite existing component files.
+> **After upgrading:** Re-add your components using `npx gluestack-ui@latest add <component>` to get the NativeWind v5 versions. Commit your changes first — re-adding will overwrite existing component files.
 
 ### UniWind upgrade path
 
@@ -148,7 +148,7 @@ Migrates from NativeWind v4 to UniWind (Tailwind v4, Expo-only). The command wil
 6. Remove `tailwind.config.js` (Tailwind v4 is CSS-first)
 7. Remove `nativewind-env.d.ts` and create `uniwind-types.d.ts`
 
-> **After upgrading:** Re-add your components using `npx gluestack-ui@alpha add <component>` to get the UniWind versions. Commit your changes first.
+> **After upgrading:** Re-add your components using `npx gluestack-ui@latest add <component>` to get the UniWind versions. Commit your changes first.
 
 > **Note:** The upgrade command is not supported for Next.js projects.
 

--- a/apps/website/app/ui/docs/home/getting-started/installation/index.mdx
+++ b/apps/website/app/ui/docs/home/getting-started/installation/index.mdx
@@ -101,7 +101,7 @@ Add this **before** installing packages to avoid build errors caused by version 
 <Tabs>
 <TabItem label="npm">
 ```bash
-npm i @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+npm i @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 npm i --save-dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0
@@ -109,7 +109,7 @@ npm i --save-dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0
 </TabItem>
 <TabItem label="yarn">
 ```bash
-yarn add @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+yarn add @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 yarn add --dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0
@@ -322,7 +322,7 @@ Uses **UniWind** with **Tailwind CSS v4** (Expo-only). Styles are processed on-d
 <Tabs>
 <TabItem label="npm">
 ```bash
-npm i @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 uniwind@^1.4.0 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.5.3 react-native-svg@^15.13.0 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+npm i @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 uniwind@^1.4.0 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.5.3 react-native-svg@^15.13.0 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 npm i --save-dev tailwindcss@^4.1.18
@@ -330,7 +330,7 @@ npm i --save-dev tailwindcss@^4.1.18
 </TabItem>
 <TabItem label="yarn">
 ```bash
-yarn add @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 uniwind@^1.4.0 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.5.3 react-native-svg@^15.13.0 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+yarn add @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 uniwind@^1.4.0 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.5.3 react-native-svg@^15.13.0 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 yarn add --dev tailwindcss@^4.1.18
@@ -887,7 +887,7 @@ Add this **before** installing packages to avoid build errors:
 <Tabs>
 <TabItem label="npm">
 ```bash
-npm i @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+npm i @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 npm i --save-dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0
@@ -895,7 +895,7 @@ npm i --save-dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0
 </TabItem>
 <TabItem label="yarn">
 ```bash
-yarn add @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+yarn add @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 yarn add --dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0

--- a/packages/create-gluestack/src/index.tsx
+++ b/packages/create-gluestack/src/index.tsx
@@ -6,8 +6,8 @@ import chalk from 'chalk';
 import { cloneProject, gitInit, installDependencies } from './utils';
 
 export async function main(args: string[]) {
-  console.log(chalk.bold.magenta('\nWelcome to gluestack-ui v5 alpha!'));
-  console.log(chalk.yellow('Creating a new project with gluestack-ui v5 alpha.'));
+  console.log(chalk.bold.magenta('\nWelcome to gluestack-ui v5!'));
+  console.log(chalk.yellow('Creating a new project with gluestack-ui v5.'));
 
   const supportedFrameworkArgs = [
     '--starter-kit-expo',

--- a/src/docs/guides/more/upgrade-to-v5/index.mdx
+++ b/src/docs/guides/more/upgrade-to-v5/index.mdx
@@ -25,7 +25,7 @@ Both engines eliminate `tailwind.config.js` in favor of defining theme tokens di
 
 ## Automated Upgrade (Recommended)
 
-<CodeBlock code="npx gluestack-ui@alpha upgrade" language="bash" />
+<CodeBlock code="npx gluestack-ui@latest upgrade" language="bash" />
 
 The CLI auto-detects your current version and asks which engine to upgrade to:
 
@@ -61,7 +61,7 @@ The CLI auto-detects your current version and asks which engine to upgrade to:
     <TableRow>
       <TableCell>NativeWind version</TableCell>
       <TableCell><InlineCode>nativewind@^4.1.23</InlineCode></TableCell>
-      <TableCell><InlineCode>nativewind@^5.0.0-preview.2</InlineCode></TableCell>
+      <TableCell><InlineCode>nativewind@^5.0.0-preview.4</InlineCode></TableCell>
     </TableRow>
     <TableRow>
       <TableCell>New package</TableCell>
@@ -98,12 +98,12 @@ The CLI auto-detects your current version and asks which engine to upgrade to:
 
 ## Automated CLI Upgrade
 
-<CodeBlock code="npx gluestack-ui@alpha upgrade" language="bash" />
+<CodeBlock code="npx gluestack-ui@latest upgrade" language="bash" />
 
 Select **NativeWind v5 (Tailwind CSS v4)**. The CLI will:
 
 1. Pin `lightningcss@1.30.1` in `package.json` overrides/resolutions
-2. Replace `nativewind@^4.x` with `nativewind@^5.0.0-preview.2`, add `react-native-css`
+2. Replace `nativewind@^4.x` with `nativewind@^5.0.0-preview.4`, add `react-native-css`
 3. Upgrade `tailwindcss` to v4, add `@tailwindcss/postcss`
 4. Rewrite `global.css` with Tailwind v4 imports and theme tokens
 5. Create `postcss.config.js`
@@ -113,7 +113,7 @@ Select **NativeWind v5 (Tailwind CSS v4)**. The CLI will:
 
 > **After upgrading:** Commit your changes, then re-add components to get NativeWind v5 versions:
 > ```bash
-> npx gluestack-ui@alpha add button accordion modal # all components you use
+> npx gluestack-ui@latest add button accordion modal # all components you use
 > ```
 
 ## Manual Migration to NativeWind v5
@@ -133,11 +133,11 @@ Add to `package.json` **before** installing other packages:
 
 <Tabs>
 <TabItem label="npm">
-<CodeBlock code={`npm install nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0
+<CodeBlock code={`npm install nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6
 npm install --save-dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0`} language="bash" />
 </TabItem>
 <TabItem label="yarn">
-<CodeBlock code={`yarn add nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0
+<CodeBlock code={`yarn add nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6
 yarn add --dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0`} language="bash" />
 </TabItem>
 </Tabs>
@@ -294,7 +294,7 @@ Tailwind v4 is CSS-first — `tailwind.config.js` is no longer needed. Before de
 ### Step 8: Re-add components
 
 ```bash
-npx gluestack-ui@alpha add button accordion modal # all components you use
+npx gluestack-ui@latest add button accordion modal # all components you use
 ```
 
 When prompted to overwrite, select **Yes** to get NativeWind v5 versions.
@@ -353,7 +353,7 @@ UniWind is an Expo-only Tailwind v4 styling engine. It processes styles natively
 
 ## Automated CLI Upgrade
 
-<CodeBlock code="npx gluestack-ui@alpha upgrade" language="bash" />
+<CodeBlock code="npx gluestack-ui@latest upgrade" language="bash" />
 
 Select **UniWind (Tailwind CSS v4, Expo-only)**. The CLI will:
 
@@ -366,7 +366,7 @@ Select **UniWind (Tailwind CSS v4, Expo-only)**. The CLI will:
 
 > **After upgrading:** Commit your changes, then re-add components:
 > ```bash
-> npx gluestack-ui@alpha add button accordion modal # all components you use
+> npx gluestack-ui@latest add button accordion modal # all components you use
 > ```
 
 ## Manual Migration to UniWind
@@ -375,12 +375,12 @@ Select **UniWind (Tailwind CSS v4, Expo-only)**. The CLI will:
 
 <Tabs>
 <TabItem label="npm">
-<CodeBlock code={`npm install uniwind@^1.3.0 @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0
+<CodeBlock code={`npm install uniwind@^1.3.0 @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6
 npm install --save-dev tailwindcss@^4.1.18
 npm uninstall nativewind`} language="bash" />
 </TabItem>
 <TabItem label="yarn">
-<CodeBlock code={`yarn add uniwind@^1.3.0 @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0
+<CodeBlock code={`yarn add uniwind@^1.3.0 @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6
 yarn add --dev tailwindcss@^4.1.18
 yarn remove nativewind`} language="bash" />
 </TabItem>
@@ -549,7 +549,7 @@ Tailwind v4 is CSS-first — `tailwind.config.js` is not used by UniWind. Migrat
 ### Step 7: Re-add components
 
 ```bash
-npx gluestack-ui@alpha add button accordion modal # all components you use
+npx gluestack-ui@latest add button accordion modal # all components you use
 ```
 
 When prompted to overwrite, select **Yes** to get UniWind versions.

--- a/src/docs/home/getting-started/cli/index.mdx
+++ b/src/docs/home/getting-started/cli/index.mdx
@@ -130,7 +130,7 @@ The upgrade command auto-detects your current gluestack-ui version and presents 
 Migrates from NativeWind v4 (Tailwind v3) to NativeWind v5 (Tailwind v4). The command will automatically:
 
 1. Pin `lightningcss@1.30.1` in `package.json` overrides/resolutions
-2. Replace `nativewind@^4.x` with `nativewind@^5.0.0-preview.2` and add `react-native-css`
+2. Replace `nativewind@^4.x` with `nativewind@^5.0.0-preview.4` and add `react-native-css`
 3. Upgrade `tailwindcss` to v4 and add `@tailwindcss/postcss`
 4. Rewrite `global.css` to Tailwind v4 format (with theme tokens)
 5. Create `postcss.config.js`
@@ -138,7 +138,7 @@ Migrates from NativeWind v4 (Tailwind v3) to NativeWind v5 (Tailwind v4). The co
 7. Prompt whether to delete `tailwind.config.js` (never auto-deleted — may contain custom tokens)
 8. Create `react-native-css-env.d.ts`
 
-> **After upgrading:** Re-add your components using `npx gluestack-ui@alpha add <component>` to get the NativeWind v5 versions. Commit your changes first — re-adding will overwrite existing component files.
+> **After upgrading:** Re-add your components using `npx gluestack-ui@latest add <component>` to get the NativeWind v5 versions. Commit your changes first — re-adding will overwrite existing component files.
 
 ### UniWind upgrade path
 
@@ -152,7 +152,7 @@ Migrates from NativeWind v4 to UniWind (Tailwind v4, Expo-only). The command wil
 6. Remove `tailwind.config.js` (Tailwind v4 is CSS-first)
 7. Remove `nativewind-env.d.ts` and create `uniwind-types.d.ts`
 
-> **After upgrading:** Re-add your components using `npx gluestack-ui@alpha add <component>` to get the UniWind versions. Commit your changes first.
+> **After upgrading:** Re-add your components using `npx gluestack-ui@latest add <component>` to get the UniWind versions. Commit your changes first.
 
 > **Note:** The upgrade command is not supported for Next.js projects.
 

--- a/src/docs/home/getting-started/installation/index.mdx
+++ b/src/docs/home/getting-started/installation/index.mdx
@@ -111,7 +111,7 @@ Add this **before** installing packages to avoid build errors caused by version 
 <Tabs>
 <TabItem label="npm">
 ```bash
-npm i @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+npm i @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 npm i --save-dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0
@@ -119,7 +119,7 @@ npm i --save-dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0
 </TabItem>
 <TabItem label="yarn">
 ```bash
-yarn add @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+yarn add @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 yarn add --dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0
@@ -332,7 +332,7 @@ Uses **UniWind** with **Tailwind CSS v4** (Expo-only). Styles are processed on-d
 <Tabs>
 <TabItem label="npm">
 ```bash
-npm i @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 uniwind@^1.4.0 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.5.3 react-native-svg@^15.13.0 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+npm i @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 uniwind@^1.4.0 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.5.3 react-native-svg@^15.13.0 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 npm i --save-dev tailwindcss@^4.1.18
@@ -340,7 +340,7 @@ npm i --save-dev tailwindcss@^4.1.18
 </TabItem>
 <TabItem label="yarn">
 ```bash
-yarn add @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 uniwind@^1.4.0 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.5.3 react-native-svg@^15.13.0 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+yarn add @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 uniwind@^1.4.0 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.5.3 react-native-svg@^15.13.0 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 yarn add --dev tailwindcss@^4.1.18
@@ -706,7 +706,7 @@ Add this **before** installing packages to avoid build errors:
 <Tabs>
 <TabItem label="npm">
 ```bash
-npm i @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+npm i @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 npm i --save-dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0
@@ -714,7 +714,7 @@ npm i --save-dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0
 </TabItem>
 <TabItem label="yarn">
 ```bash
-yarn add @gluestack-ui/core@^5.0.0-alpha.0 @gluestack-ui/utils@^5.0.1-alpha.0 nativewind@^5.0.0-preview.2 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
+yarn add @gluestack-ui/core@^5.0.15 @gluestack-ui/utils@^5.0.6 nativewind@^5.0.0-preview.4 react-native-css@^3.0.4 react-native-safe-area-context@^5.6.1 react-aria@^3.45.0 @expo/html-elements@^0.12.5 tailwind-variants@^0.1.20 @legendapp/motion@^2.4.0 react-native-svg@^15.15.3 react-stately@^3.39.0 react-native-reanimated@~4.2.1 react-native-worklets@^0.7.1
 ```
 ```bash
 yarn add --dev tailwindcss@^4.2.0 @tailwindcss/postcss@^4.2.0


### PR DESCRIPTION
This PR refreshes the v5 upgrade and installation documentation now that the gluestack-ui v5 alpha phase has ended.

## Changes
- Replaces `gluestack-ui@alpha` CLI examples with `gluestack-ui@latest`.
- Updates v5 package install examples from alpha ranges to stable packages:
  - `@gluestack-ui/core@^5.0.15`
  - `@gluestack-ui/utils@^5.0.6`
- Updates NativeWind v5 examples from `^5.0.0-preview.2` to `^5.0.0-preview.4`.