### PR TITLE
Fix/button text color theme

### DIFF
--- a/apps/website/components/page-components/landing-page/BadgeComponent/index.tsx
+++ b/apps/website/components/page-components/landing-page/BadgeComponent/index.tsx
@@ -31,8 +31,9 @@ const BadgeComponent = () => {
   };
   return isBadgeVisible ? (
     <Box
-      className={`web:fixed web:bottom-6 web:sm:left-6 self-center sm:w-auto sm:p-0 px-6 w-full sm:self-end my-0 mx-auto z-50 ${shouldAnimate ? 'slide-up' : ''
-        }`}
+      className={`web:fixed web:bottom-6 web:sm:left-6 self-center sm:w-auto sm:p-0 px-6 w-full sm:self-end my-0 mx-auto z-50 ${
+        shouldAnimate ? 'slide-up' : ''
+      }`}
     >
       <Badge className="p-4 gap-3 md:flex-row flex-col rounded-xl bg-foreground">
         <VStack className="md:items-start items-center md:self-center self-start">

--- a/apps/website/components/page-components/landing-page/BadgeComponent/index.tsx
+++ b/apps/website/components/page-components/landing-page/BadgeComponent/index.tsx
@@ -31,9 +31,8 @@ const BadgeComponent = () => {
   };
   return isBadgeVisible ? (
     <Box
-      className={`web:fixed web:bottom-6 web:sm:left-6 self-center sm:w-auto sm:p-0 px-6 w-full sm:self-end my-0 mx-auto z-50 ${
-        shouldAnimate ? 'slide-up' : ''
-      }`}
+      className={`web:fixed web:bottom-6 web:sm:left-6 self-center sm:w-auto sm:p-0 px-6 w-full sm:self-end my-0 mx-auto z-50 ${shouldAnimate ? 'slide-up' : ''
+        }`}
     >
       <Badge className="p-4 gap-3 md:flex-row flex-col rounded-xl bg-foreground">
         <VStack className="md:items-start items-center md:self-center self-start">
@@ -71,9 +70,11 @@ const BadgeComponent = () => {
             action="secondary"
             variant="outline"
             onPress={handleDenyClick}
-            className="sm:w-auto border-background"
+            className="sm:w-auto border-background bg-transparent data-[hover=true]:bg-background hover:bg-background dark:bg-transparent dark:data-[hover=true]:bg-background dark:hover:bg-background"
           >
-            <ButtonText className="text-background">Deny</ButtonText>
+            <ButtonText className="text-background data-[hover=true]:text-foreground hover:text-foreground dark:data-[hover=true]:text-foreground dark:hover:text-foreground">
+              Deny
+            </ButtonText>
           </Button>
           <Button
             onPress={handleEulaAccept}


### PR DESCRIPTION
## Summary

Fixes the button text color on hover to ensure proper contrast in both light and dark themes.

## Changes

- Update hover text color for the outlined button
- Ensure text remains readable in light mode
- Ensure text remains readable in dark mode
##before/After
<img width="164" height="63" alt="Screenshot 2026-07-18 at 10 33 36 PM" src="https://github.com/user-attachments/assets/056585a6-1ab8-461e-ba6d-e86d716c2e54" />
<img width="175" height="83" alt="Screenshot 2026-07-18 at 10 33 47 PM" src="https://github.com/user-attachments/assets/f37b4305-b253-4837-b993-b351bd0b8e53" />



## Testing

- [x] Verified hover state in light theme
- [x] Verified hover state in dark theme