### PR TITLE
fix: align docs and examples with v5 component props, add Avatar size…

### DIFF
--- a/apps/kitchen-sink/app/(home)/components/menu.tsx
+++ b/apps/kitchen-sink/app/(home)/components/menu.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { UsageVariantFlatList } from '@/components/custom/component-presentation/usage-variant-flatlist';
 
 const ExampleBasic = () => {
-return (
+  return (
     <Menu
       placement="top"
       offset={5}
@@ -18,27 +18,27 @@ return (
           <Button {...triggerProps}>
             <ButtonText>Menu</ButtonText>
           </Button>
-        )
+        );
       }}
     >
       <MenuItem key="Add account" textValue="Add account">
-        <Icon as={AddIcon} size="sm" className="mr-2 " />
-        <MenuItemLabel size="sm">Add account</MenuItemLabel>
+        <Icon as={AddIcon} size="sm" className="mr-2" />
+        <MenuItemLabel>Add account</MenuItemLabel>
       </MenuItem>
       <MenuItem key="Community" textValue="Community">
-        <Icon as={GlobeIcon} size="sm" className="mr-2 " />
-        <MenuItemLabel size="sm">Community</MenuItemLabel>
+        <Icon as={GlobeIcon} size="sm" className="mr-2" />
+        <MenuItemLabel>Community</MenuItemLabel>
       </MenuItem>
       <MenuItem key="Plugins" textValue="Plugins">
-        <Icon as={PlayIcon} size="sm" className="mr-2 " />
-        <MenuItemLabel size="sm">Plugins</MenuItemLabel>
+        <Icon as={PlayIcon} size="sm" className="mr-2" />
+        <MenuItemLabel>Plugins</MenuItemLabel>
       </MenuItem>
       <MenuItem key="Settings" textValue="Settings">
-        <Icon as={SettingsIcon} size="sm" className="mr-2 " />
-        <MenuItemLabel size="sm">Settings</MenuItemLabel>
+        <Icon as={SettingsIcon} size="sm" className="mr-2" />
+        <MenuItemLabel>Settings</MenuItemLabel>
       </MenuItem>
     </Menu>
-  )
+  );
 };
 
 const ExampleMenuWithTag = () => {

--- a/src/components/ui/alert/docs/index.mdx
+++ b/src/components/ui/alert/docs/index.mdx
@@ -33,8 +33,6 @@ This is an illustration of **Alert** component.
 <br />
 ## Installation
 
-
-
 <Tabs>
 <TabItem label="CLI">
 ### Run the following command:
@@ -96,18 +94,10 @@ Contains all alert related layout style props and actions. It inherits all the p
     <TableBody>
       <TableRow>
         <TableCell>
-          <InlineCode>action</InlineCode>
-        </TableCell>
-        <TableCell>error | warning | success | info | muted</TableCell>
-        <TableCell>info</TableCell>
-        <TableCell>Determines the color scheme of the alert.</TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell>
           <InlineCode>variant</InlineCode>
         </TableCell>
-        <TableCell>solid | outline</TableCell>
-        <TableCell>solid</TableCell>
+        <TableCell>default | destructive</TableCell>
+        <TableCell>default</TableCell>
         <TableCell>Determines the visual style of the alert.</TableCell>
       </TableRow>
     </TableBody>

--- a/src/components/ui/avatar/docs/index.mdx
+++ b/src/components/ui/avatar/docs/index.mdx
@@ -10,7 +10,6 @@ pageDescription: Enhance your UI with our React Native Avatar component. Explore
 showHeader: true
 ---
 
-
 import {
   Table,
   TableHeader,
@@ -22,7 +21,6 @@ import {
 import { InlineCode } from '@/docs-components/inline-code';
 import { AnatomyImage } from '@/docs-components/anatomy-image';
 import { Tabs, TabItem } from '@/docs-components/tabs';
-
 
 # Avatar
 
@@ -40,11 +38,13 @@ This is an illustration of **Avatar** component.
 <TabItem label="CLI">
 ### Run the following command:
 
-<CodeBlock code={`${process.env.NEXT_PUBLIC_GLUESTACK_COMMAND || 'npx gluestack-ui'} add avatar`} language="bash" />
+<CodeBlock
+  code={`${process.env.NEXT_PUBLIC_GLUESTACK_COMMAND || 'npx gluestack-ui'} add avatar`}
+  language="bash"
+/>
 
 </TabItem>
 <TabItem label="Manual">
-
 
 ### Step 1: Copy and paste the following code into your project.
 
@@ -138,7 +138,7 @@ Avatar component is created using View component from react-native. It extends a
       <TableCell>
         <InlineCode>size</InlineCode>
       </TableCell>
-      <TableCell>xs | sm | md | lg | xl | 2xl</TableCell>
+      <TableCell>sm | md | lg</TableCell>
       <TableCell>md</TableCell>
       <TableCell>Determines the size of the avatar.</TableCell>
     </TableRow>
@@ -148,6 +148,8 @@ Avatar component is created using View component from react-native. It extends a
 ### Examples
 
 The Examples section provides visual representations of the different variants of the component, allowing you to quickly and easily determine which one best fits your needs. Simply copy the code and integrate it into your project.
+
+/// {Example:sizes} ///
 
 /// {Example:with-letters} ///
 

--- a/src/components/ui/avatar/examples/sizes/meta.json
+++ b/src/components/ui/avatar/examples/sizes/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Avatar Sizes",
+  "description": "Use the size prop to change the size of the avatar. Available sizes are sm, md, and lg.",
+  "argTypes": {},
+  "reactLive": {
+    "Avatar": "@/components/ui/avatar",
+    "AvatarFallbackText": "@/components/ui/avatar",
+    "HStack": "@/components/ui/hstack"
+  }
+}

--- a/src/components/ui/avatar/examples/sizes/template.handlebars
+++ b/src/components/ui/avatar/examples/sizes/template.handlebars
@@ -1,0 +1,15 @@
+function Example() {
+  return (
+    <HStack space="lg" className="items-center">
+      <Avatar size="sm">
+        <AvatarFallbackText>JD</AvatarFallbackText>
+      </Avatar>
+      <Avatar size="md">
+        <AvatarFallbackText>JD</AvatarFallbackText>
+      </Avatar>
+      <Avatar size="lg">
+        <AvatarFallbackText>JD</AvatarFallbackText>
+      </Avatar>
+    </HStack>
+  );
+}

--- a/src/components/ui/avatar/index.tsx
+++ b/src/components/ui/avatar/index.tsx
@@ -6,6 +6,8 @@ import type { VariantProps } from '@gluestack-ui/utils/nativewind-utils';
 import { tva, withStyleContext } from '@gluestack-ui/utils/nativewind-utils';
 const SCOPE = 'AVATAR';
 
+const AvatarSizeContext = React.createContext<'sm' | 'md' | 'lg'>('md');
+
 const UIAvatar = createAvatar({
   Root: withStyleContext(View, SCOPE),
   Badge: View,
@@ -15,11 +17,25 @@ const UIAvatar = createAvatar({
 });
 
 const avatarStyle = tva({
-  base: 'relative flex h-12 w-12 shrink-0 rounded-full bg-muted items-center justify-center group-[.avatar-group]/avatar-group:-ml-2.5',
+  base: 'relative flex shrink-0 rounded-full bg-muted items-center justify-center group-[.avatar-group]/avatar-group:-ml-2.5',
+  variants: {
+    size: {
+      sm: 'h-8 w-8',
+      md: 'h-12 w-12',
+      lg: 'h-16 w-16',
+    },
+  },
 });
 
 const avatarFallbackTextStyle = tva({
-  base: 'text-foreground text-xs font-medium text-transform:uppercase',
+  base: 'text-foreground font-medium text-transform:uppercase',
+  parentVariants: {
+    size: {
+      sm: 'text-2xs',
+      md: 'text-xs',
+      lg: 'text-sm',
+    },
+  },
 });
 
 const avatarGroupStyle = tva({
@@ -27,7 +43,14 @@ const avatarGroupStyle = tva({
 });
 
 const avatarBadgeStyle = tva({
-  base: 'absolute h-3 w-3 rounded-full border-2 border-background right-0 bottom-0 bg-green-500',
+  base: 'absolute rounded-full border-2 border-background right-0 bottom-0 bg-green-500',
+  parentVariants: {
+    size: {
+      sm: 'h-1.5 w-1.5',
+      md: 'h-3 w-3',
+      lg: 'h-3.5 w-3.5',
+    },
+  },
 });
 
 const avatarImageStyle = tva({
@@ -43,14 +66,18 @@ type IAvatarProps = Omit<
 const Avatar = React.forwardRef<
   React.ComponentRef<typeof UIAvatar>,
   IAvatarProps
->(function Avatar({ className, ...props }, ref) {
+>(function Avatar({ className, size = 'md', children, ...props }, ref) {
   return (
-    <UIAvatar
-      ref={ref}
-      {...props}
-      className={avatarStyle({ class: className })}
-      context={{}}
-    />
+    <AvatarSizeContext.Provider value={size}>
+      <UIAvatar
+        ref={ref}
+        {...props}
+        className={avatarStyle({ size, class: className })}
+        context={{}}
+      >
+        {children}
+      </UIAvatar>
+    </AvatarSizeContext.Provider>
   );
 });
 
@@ -61,11 +88,15 @@ const AvatarBadge = React.forwardRef<
   React.ComponentRef<typeof UIAvatar.Badge>,
   IAvatarBadgeProps
 >(function AvatarBadge({ className, ...props }, ref) {
+  const size = React.useContext(AvatarSizeContext);
   return (
     <UIAvatar.Badge
       ref={ref}
       {...props}
-      className={avatarBadgeStyle({ class: className })}
+      className={avatarBadgeStyle({
+        parentVariants: { size },
+        class: className,
+      })}
     />
   );
 });
@@ -78,11 +109,15 @@ const AvatarFallbackText = React.forwardRef<
   React.ComponentRef<typeof UIAvatar.FallbackText>,
   IAvatarFallbackTextProps
 >(function AvatarFallbackText({ className, ...props }, ref) {
+  const size = React.useContext(AvatarSizeContext);
   return (
     <UIAvatar.FallbackText
       ref={ref}
       {...props}
-      className={avatarFallbackTextStyle({ class: className })}
+      className={avatarFallbackTextStyle({
+        parentVariants: { size },
+        class: className,
+      })}
     />
   );
 });
@@ -134,5 +169,5 @@ export {
   AvatarFallback,
   AvatarFallbackText,
   AvatarGroup,
-  AvatarImage
+  AvatarImage,
 };

--- a/src/components/ui/badge/docs/index.mdx
+++ b/src/components/ui/badge/docs/index.mdx
@@ -109,27 +109,11 @@ Badge component is created using View component from react-native. It extends al
   <TableBody>
     <TableRow>
       <TableCell>
-        <InlineCode>action</InlineCode>
-      </TableCell>
-      <TableCell>error | warning | success | info | muted</TableCell>
-      <TableCell>success</TableCell>
-      <TableCell>Determines the color scheme of the badge.</TableCell>
-    </TableRow>
-    <TableRow>
-      <TableCell>
         <InlineCode>variant</InlineCode>
       </TableCell>
-      <TableCell>solid | outline</TableCell>
-      <TableCell>solid</TableCell>
+      <TableCell>default | secondary | destructive | outline</TableCell>
+      <TableCell>default</TableCell>
       <TableCell>Determines the visual style of the badge.</TableCell>
-    </TableRow>
-    <TableRow>
-      <TableCell>
-        <InlineCode>size</InlineCode>
-      </TableCell>
-      <TableCell>sm | md | lg</TableCell>
-      <TableCell>md</TableCell>
-      <TableCell>Determines the size of the badge.</TableCell>
     </TableRow>
   </TableBody>
 </Table>

--- a/src/components/ui/card/docs/index.mdx
+++ b/src/components/ui/card/docs/index.mdx
@@ -43,10 +43,10 @@ This is an illustration of **Card** component.
 
 ### Step 1: Copy and paste the following code into index.tsx in your project.
 
-
 ```jsx
 %%-- File: src/components/ui/card/index.tsx --%%
 ```
+
 > Note: **Step 2** is optional and only required if you want to add support for [React Server Components](https://vercel.com/blog/understanding-react-server-components), You can skip this and jump to **Step 3** directly if you don't have this requirement.
 
 ### Step 2(optional): Copy and paste the following code into index.web.tsx in your project.
@@ -65,7 +65,6 @@ This is an illustration of **Card** component.
 
 </TabItem>
 </Tabs>
-
 
 ## API Reference
 
@@ -126,15 +125,8 @@ Renders a `<div />` on web and a `View` on native.
         <TableCell>
           <InlineCode>size</InlineCode>
         </TableCell>
-        <TableCell>sm | md | lg</TableCell>
-        <TableCell>md</TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell>
-          <InlineCode>variant</InlineCode>
-        </TableCell>
-        <TableCell>elevated | outline | ghost | filled</TableCell>
-        <TableCell>elevated</TableCell>
+        <TableCell>default | sm</TableCell>
+        <TableCell>default</TableCell>
       </TableRow>
     </TableBody>
   </Table>

--- a/src/components/ui/checkbox/docs/index.mdx
+++ b/src/components/ui/checkbox/docs/index.mdx
@@ -41,7 +41,6 @@ This is an illustration of **Checkbox** component.
 </TabItem>
 <TabItem label="Manual">
 
-
 ### Step 1: Install the following dependencies:
 
 ```bash
@@ -58,8 +57,6 @@ npm i lucide-react-native
 
 </TabItem>
 </Tabs>
-
-
 
 ## API Reference
 
@@ -344,15 +341,7 @@ Checkbox component is created using Pressable component from react-native. It ex
         <TableHeaderCell>Default</TableHeaderCell>
       </TableRow>
     </TableHeader>
-    <TableBody>
-      <TableRow>
-        <TableCell>
-          <InlineCode>size</InlineCode>
-        </TableCell>
-        <TableCell>lg | md | sm</TableCell>
-        <TableCell>md</TableCell>
-      </TableRow>
-    </TableBody>
+    <TableBody></TableBody>
   </Table>
 </>
 

--- a/src/components/ui/form-control/examples/basic/template.handlebars
+++ b/src/components/ui/form-control/examples/basic/template.handlebars
@@ -21,7 +21,7 @@ function App () {
         <FormControlLabel>
           <FormControlLabelText>Password</FormControlLabelText>
         </FormControlLabel>
-        <Input className="my-1" size="{{size}}">
+        <Input className="my-1">
           <InputField
             type="password"
             placeholder="password"

--- a/src/components/ui/heading/docs/index.mdx
+++ b/src/components/ui/heading/docs/index.mdx
@@ -32,7 +32,6 @@ This is an illustration of **Heading** component.
 
 ## Installation
 
-
 <Tabs>
 <TabItem label="CLI">
 ### Run the following command:
@@ -64,7 +63,6 @@ This is an illustration of **Heading** component.
 
 </TabItem>
 </Tabs>
-
 
 ## API Reference
 
@@ -229,7 +227,7 @@ Heading component is created using Heading component from @expo/html-elements on
         <InlineCode>size</InlineCode>
       </TableCell>
       <TableCell>5xl | 4xl | 3xl | 2xl | xl | lg | md | sm | xs</TableCell>
-      <TableCell>md</TableCell>
+      <TableCell>lg</TableCell>
     </TableRow>
   </TableBody>
 </Table>

--- a/src/components/ui/input/docs/index.mdx
+++ b/src/components/ui/input/docs/index.mdx
@@ -50,7 +50,6 @@ This is an illustration of **Input** component.
 </TabItem>
 </Tabs>
 
-
 ## API Reference
 
 To use this component in your project, include the following import statement in your file.
@@ -165,22 +164,6 @@ It inherits all the properties of React Native's [View](https://reactnative.dev/
         <TableCell>boolean</TableCell>
         <TableCell>false</TableCell>
         <TableCell>If true, the input value cannot be edited</TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell>
-          <InlineCode>size</InlineCode>
-        </TableCell>
-        <TableCell>xl | lg | md | sm</TableCell>
-        <TableCell>md</TableCell>
-        <TableCell>The size of the input</TableCell>
-      </TableRow>
-      <TableRow>
-        <TableCell>
-          <InlineCode>variant</InlineCode>
-        </TableCell>
-        <TableCell>underlined | outline | rounded</TableCell>
-        <TableCell>outline</TableCell>
-        <TableCell>The variant of the input</TableCell>
       </TableRow>
     </TableBody>
   </Table>

--- a/src/components/ui/input/examples/basic/template.handlebars
+++ b/src/components/ui/input/examples/basic/template.handlebars
@@ -1,6 +1,6 @@
 function Example() {
   return (
-    <Input variant="{{variant}}" size="{{size}}" isDisabled={ {{isDisabled}} } isInvalid={ {{isInvalid}} } isReadOnly={ {{isReadOnly}} }>
+    <Input isDisabled={ {{isDisabled}} } isInvalid={ {{isInvalid}} } isReadOnly={ {{isReadOnly}} }>
         <InputField placeholder="Enter Text here..." />
     </Input>
   )

--- a/src/components/ui/menu/examples/basic/template.handlebars
+++ b/src/components/ui/menu/examples/basic/template.handlebars
@@ -1,33 +1,32 @@
-function Example() {
-  return (
-    <Menu
-      placement="{{placement}}"
-      offset={5}
-      disabledKeys={["Settings"]}
-      trigger={({ ...triggerProps }) => {
-        return (
-          <Button {...triggerProps}>
-            <ButtonText>Menu</ButtonText>
-          </Button>
-        )
-      }}
-    >
-      <MenuItem key="Add account" textValue="Add account">
-        <Icon as={AddIcon} size="sm" className="mr-2 " />
-        <MenuItemLabel size="sm">Add account</MenuItemLabel>
-      </MenuItem>
-      <MenuItem key="Community" textValue="Community">
-        <Icon as={GlobeIcon} size="sm" className="mr-2 " />
-        <MenuItemLabel size="sm">Community</MenuItemLabel>
-      </MenuItem>
-      <MenuItem key="Plugins" textValue="Plugins">
-        <Icon as={PlayIcon} size="sm" className="mr-2 " />
-        <MenuItemLabel size="sm">Plugins</MenuItemLabel>
-      </MenuItem>
-      <MenuItem key="Settings" textValue="Settings">
-        <Icon as={SettingsIcon} size="sm" className="mr-2 " />
-        <MenuItemLabel size="sm">Settings</MenuItemLabel>
-      </MenuItem>
-    </Menu>
-  )
-}
+function Example() { return (
+<Menu
+  placement='{{placement}}'
+  offset='{5}'
+  disabledKeys='{["Settings"]}'
+  trigger='{({'
+  ...triggerProps
+  })
+>
+  { return (
+  <Button {...triggerProps}>
+    <ButtonText>Menu</ButtonText>
+  </Button>
+  ) }} >
+  <MenuItem key='Add account' textValue='Add account'>
+    <Icon as='{AddIcon}' size='sm' className='mr-2 ' />
+    <MenuItemLabel>Add account</MenuItemLabel>
+  </MenuItem>
+  <MenuItem key='Community' textValue='Community'>
+    <Icon as='{GlobeIcon}' size='sm' className='mr-2 ' />
+    <MenuItemLabel>Community</MenuItemLabel>
+  </MenuItem>
+  <MenuItem key='Plugins' textValue='Plugins'>
+    <Icon as='{PlayIcon}' size='sm' className='mr-2 ' />
+    <MenuItemLabel>Plugins</MenuItemLabel>
+  </MenuItem>
+  <MenuItem key='Settings' textValue='Settings'>
+    <Icon as='{SettingsIcon}' size='sm' className='mr-2 ' />
+    <MenuItemLabel>Settings</MenuItemLabel>
+  </MenuItem>
+</Menu>
+) }

--- a/src/components/ui/popover/docs/index.mdx
+++ b/src/components/ui/popover/docs/index.mdx
@@ -392,15 +392,7 @@ Popover component is created using View component from react-native. It extends 
         <TableHeaderCell>Default</TableHeaderCell>
       </TableRow>
     </TableHeader>
-    <TableBody>
-      <TableRow>
-        <TableCell>
-          <InlineCode>size</InlineCode>
-        </TableCell>
-        <TableCell>xs | sm | md | lg | full</TableCell>
-        <TableCell>md</TableCell>
-      </TableRow>
-    </TableBody>
+    <TableBody></TableBody>
   </Table>
 </>
 

--- a/src/components/ui/progress/docs/index.mdx
+++ b/src/components/ui/progress/docs/index.mdx
@@ -128,13 +128,6 @@ Progress component is created using View component from react-native. It extends
   <TableBody>
     <TableRow>
       <TableCell>
-        <InlineCode>size</InlineCode>
-      </TableCell>
-      <TableCell>xs | sm | md | lg | xl | 2xl</TableCell>
-      <TableCell>md</TableCell>
-    </TableRow>
-    <TableRow>
-      <TableCell>
         <InlineCode>orientation</InlineCode>
       </TableCell>
       <TableCell>vertical | horizontal</TableCell>

--- a/src/components/ui/radio/docs/index.mdx
+++ b/src/components/ui/radio/docs/index.mdx
@@ -36,12 +36,13 @@ This is an illustration of **Radio** component.
 
 ### Run the following command:
 
-<CodeBlock code={`${process.env.NEXT_PUBLIC_GLUESTACK_COMMAND || 'npx gluestack-ui'} add radio`} language="bash" />
-
+<CodeBlock
+  code={`${process.env.NEXT_PUBLIC_GLUESTACK_COMMAND || 'npx gluestack-ui'} add radio`}
+  language="bash"
+/>
 
 </TabItem>
 <TabItem label="Manual">
-
 
 ### Step 1: Install the following dependencies:
 
@@ -59,7 +60,6 @@ npm i lucide-react-native
 
 </TabItem>
 </Tabs>
-
 
 ## API Reference
 
@@ -162,6 +162,14 @@ It inherits all the properties of React Native's [View](https://reactnative.dev/
           <TableCell>bool</TableCell>
           <TableCell>false</TableCell>
           <TableCell>{`To manually set indeterminate to the radio.`}</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>
+            <InlineCode>size</InlineCode>
+          </TableCell>
+          <TableCell>sm | md | lg</TableCell>
+          <TableCell>md</TableCell>
+          <TableCell>{`The size of the radio and its indicator/label.`}</TableCell>
         </TableRow>
       </TableBody>
     </Table>

--- a/src/components/ui/tabs/docs/index.mdx
+++ b/src/components/ui/tabs/docs/index.mdx
@@ -38,13 +38,13 @@ This is an illustration of **Tabs** component.
 
 ### Run the following command:
 
-<CodeBlock code={`${process.env.NEXT_PUBLIC_GLUESTACK_COMMAND || 'npx gluestack-ui'} add tabs`} language="bash" />
-
+<CodeBlock
+  code={`${process.env.NEXT_PUBLIC_GLUESTACK_COMMAND || 'npx gluestack-ui'} add tabs`}
+  language="bash"
+/>
 
 </TabItem>
 <TabItem label="Manual">
-
-
 
 > Note: At present, we have integrated `react-native-reanimated` for animations. You have the option to remove this and implement your own custom animation wrapper.
 
@@ -72,7 +72,6 @@ npm i react-native-reanimated
 
 </TabItem>
 </DocTabs>
-
 
 ## API Reference
 
@@ -132,52 +131,70 @@ Contains all the tabs component parts.
   </TableHeader>
   <TableBody>
     <TableRow>
-      <TableCell><InlineCode>value</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>value</InlineCode>
+      </TableCell>
       <TableCell>string</TableCell>
       <TableCell>-</TableCell>
-      <TableCell>The controlled value of the tab to activate. Use with onValueChange.</TableCell>
+      <TableCell>
+        The controlled value of the tab to activate. Use with onValueChange.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>defaultValue</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>defaultValue</InlineCode>
+      </TableCell>
       <TableCell>string</TableCell>
       <TableCell>-</TableCell>
-      <TableCell>The value of the tab that should be active when initially rendered. Use when you do not need to control the state.</TableCell>
+      <TableCell>
+        The value of the tab that should be active when initially rendered. Use
+        when you do not need to control the state.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>onValueChange</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>onValueChange</InlineCode>
+      </TableCell>
       <TableCell>(value: string) =&gt; void</TableCell>
       <TableCell>-</TableCell>
       <TableCell>Event handler called when the value changes.</TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>orientation</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>orientation</InlineCode>
+      </TableCell>
       <TableCell>'horizontal' | 'vertical'</TableCell>
       <TableCell>'horizontal'</TableCell>
       <TableCell>The orientation of the tabs.</TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>activationMode</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>activationMode</InlineCode>
+      </TableCell>
       <TableCell>'automatic' | 'manual'</TableCell>
       <TableCell>'automatic'</TableCell>
-      <TableCell>Whether tabs activate automatically on focus or manually with Enter/Space.</TableCell>
+      <TableCell>
+        Whether tabs activate automatically on focus or manually with
+        Enter/Space.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>disabled</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>disabled</InlineCode>
+      </TableCell>
       <TableCell>boolean</TableCell>
       <TableCell>false</TableCell>
-      <TableCell>When true, prevents the user from interacting with the tabs.</TableCell>
+      <TableCell>
+        When true, prevents the user from interacting with the tabs.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>variant</InlineCode></TableCell>
-      <TableCell>'underlined' | 'filled' | 'enclosed'</TableCell>
-      <TableCell>'underlined'</TableCell>
+      <TableCell>
+        <InlineCode>variant</InlineCode>
+      </TableCell>
+      <TableCell>'underlined' | 'filled'</TableCell>
+      <TableCell>'filled'</TableCell>
       <TableCell>The visual style variant of the tabs.</TableCell>
-    </TableRow>
-    <TableRow>
-      <TableCell><InlineCode>size</InlineCode></TableCell>
-      <TableCell>'sm' | 'md' | 'lg'</TableCell>
-      <TableCell>'md'</TableCell>
-      <TableCell>The size of the tabs.</TableCell>
     </TableRow>
   </TableBody>
 </Table>
@@ -197,16 +214,24 @@ Contains the triggers that are aligned along the edge of the active content.
   </TableHeader>
   <TableBody>
     <TableRow>
-      <TableCell><InlineCode>scrollable</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>scrollable</InlineCode>
+      </TableCell>
       <TableCell>boolean</TableCell>
       <TableCell>false</TableCell>
-      <TableCell>When true, enables horizontal scrolling for overflow tabs.</TableCell>
+      <TableCell>
+        When true, enables horizontal scrolling for overflow tabs.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>snapToCenter</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>snapToCenter</InlineCode>
+      </TableCell>
       <TableCell>boolean</TableCell>
       <TableCell>true</TableCell>
-      <TableCell>When scrollable is true, snaps the selected tab to center.</TableCell>
+      <TableCell>
+        When scrollable is true, snaps the selected tab to center.
+      </TableCell>
     </TableRow>
   </TableBody>
 </Table>
@@ -226,16 +251,24 @@ The button that activates its associated content.
   </TableHeader>
   <TableBody>
     <TableRow>
-      <TableCell><InlineCode>value</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>value</InlineCode>
+      </TableCell>
       <TableCell>string</TableCell>
       <TableCell>-</TableCell>
-      <TableCell>A unique value that associates the trigger with a content.</TableCell>
+      <TableCell>
+        A unique value that associates the trigger with a content.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>disabled</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>disabled</InlineCode>
+      </TableCell>
       <TableCell>boolean</TableCell>
       <TableCell>false</TableCell>
-      <TableCell>When true, prevents the user from interacting with the tab.</TableCell>
+      <TableCell>
+        When true, prevents the user from interacting with the tab.
+      </TableCell>
     </TableRow>
   </TableBody>
 </Table>
@@ -255,16 +288,25 @@ Contains the content associated with each trigger.
   </TableHeader>
   <TableBody>
     <TableRow>
-      <TableCell><InlineCode>value</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>value</InlineCode>
+      </TableCell>
       <TableCell>string</TableCell>
       <TableCell>-</TableCell>
-      <TableCell>A unique value that associates the content with a trigger.</TableCell>
+      <TableCell>
+        A unique value that associates the content with a trigger.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>forceMount</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>forceMount</InlineCode>
+      </TableCell>
       <TableCell>boolean</TableCell>
       <TableCell>false</TableCell>
-      <TableCell>Used to force mounting when more control is needed. Useful for animation.</TableCell>
+      <TableCell>
+        Used to force mounting when more control is needed. Useful for
+        animation.
+      </TableCell>
     </TableRow>
   </TableBody>
 </Table>
@@ -290,7 +332,9 @@ The icon displayed within a tab trigger.
   </TableHeader>
   <TableBody>
     <TableRow>
-      <TableCell><InlineCode>as</InlineCode></TableCell>
+      <TableCell>
+        <InlineCode>as</InlineCode>
+      </TableCell>
       <TableCell>React.ComponentType</TableCell>
       <TableCell>-</TableCell>
       <TableCell>The icon component to render.</TableCell>
@@ -319,32 +363,65 @@ Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/pa
   </TableHeader>
   <TableBody>
     <TableRow>
-      <TableCell><InlineCode>Tab</InlineCode></TableCell>
-      <TableCell>When focus moves onto the tabs, focuses the active trigger. When a trigger is focused, moves focus to the active content.</TableCell>
+      <TableCell>
+        <InlineCode>Tab</InlineCode>
+      </TableCell>
+      <TableCell>
+        When focus moves onto the tabs, focuses the active trigger. When a
+        trigger is focused, moves focus to the active content.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>ArrowDown</InlineCode></TableCell>
-      <TableCell>Moves focus to the next trigger in vertical orientation and activates its associated content.</TableCell>
+      <TableCell>
+        <InlineCode>ArrowDown</InlineCode>
+      </TableCell>
+      <TableCell>
+        Moves focus to the next trigger in vertical orientation and activates
+        its associated content.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>ArrowUp</InlineCode></TableCell>
-      <TableCell>Moves focus to the previous trigger in vertical orientation and activates its associated content.</TableCell>
+      <TableCell>
+        <InlineCode>ArrowUp</InlineCode>
+      </TableCell>
+      <TableCell>
+        Moves focus to the previous trigger in vertical orientation and
+        activates its associated content.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>ArrowLeft</InlineCode></TableCell>
-      <TableCell>Moves focus to the previous trigger in horizontal orientation and activates its associated content.</TableCell>
+      <TableCell>
+        <InlineCode>ArrowLeft</InlineCode>
+      </TableCell>
+      <TableCell>
+        Moves focus to the previous trigger in horizontal orientation and
+        activates its associated content.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>ArrowRight</InlineCode></TableCell>
-      <TableCell>Moves focus to the next trigger in horizontal orientation and activates its associated content.</TableCell>
+      <TableCell>
+        <InlineCode>ArrowRight</InlineCode>
+      </TableCell>
+      <TableCell>
+        Moves focus to the next trigger in horizontal orientation and activates
+        its associated content.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>Home</InlineCode></TableCell>
-      <TableCell>Moves focus to the first trigger and activates its associated content.</TableCell>
+      <TableCell>
+        <InlineCode>Home</InlineCode>
+      </TableCell>
+      <TableCell>
+        Moves focus to the first trigger and activates its associated content.
+      </TableCell>
     </TableRow>
     <TableRow>
-      <TableCell><InlineCode>End</InlineCode></TableCell>
-      <TableCell>Moves focus to the last trigger and activates its associated content.</TableCell>
+      <TableCell>
+        <InlineCode>End</InlineCode>
+      </TableCell>
+      <TableCell>
+        Moves focus to the last trigger and activates its associated content.
+      </TableCell>
     </TableRow>
   </TableBody>
 </Table>
@@ -367,11 +444,9 @@ Adheres to the [Tabs WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/pa
 
 /// {Example:variants} ///
 
-
 ### Scrollable
 
 /// {Example:scrollable} ///
-
 
 ### Controlled
 

--- a/src/components/ui/textarea/docs/index.mdx
+++ b/src/components/ui/textarea/docs/index.mdx
@@ -42,7 +42,6 @@ This is an illustration of **TextArea** component.
   </TabItem>
   <TabItem label="Manual">
 
-
 ### Step 1: Copy and paste the following code into your project.
 
 ```jsx
@@ -53,8 +52,6 @@ This is an illustration of **TextArea** component.
 
 </TabItem>
 </Tabs>
-
-
 
 ## API Reference
 
@@ -96,6 +93,14 @@ It inherits all the properties of React Native's [View](https://reactnative.dev/
         </TableRow>
       </TableHeader>
       <TableBody>
+        <TableRow>
+          <TableCell>
+            <InlineCode>variant</InlineCode>
+          </TableCell>
+          <TableCell>default</TableCell>
+          <TableCell>default</TableCell>
+          <TableCell>The variant of the textarea.</TableCell>
+        </TableRow>
         <TableRow>
           <TableCell>
             <InlineCode>size</InlineCode>

--- a/src/components/ui/toast/docs/index.mdx
+++ b/src/components/ui/toast/docs/index.mdx
@@ -38,8 +38,11 @@ This is an illustration of **Toast** component.
   <TabItem label="CLI">
 
 ### Run the following command:
-<CodeBlock code={`${process.env.NEXT_PUBLIC_GLUESTACK_COMMAND || 'npx gluestack-ui'} add toast`} language="bash" />
 
+<CodeBlock
+  code={`${process.env.NEXT_PUBLIC_GLUESTACK_COMMAND || 'npx gluestack-ui'} add toast`}
+  language="bash"
+/>
 
   </TabItem>
   <TabItem label="Manual">
@@ -62,7 +65,6 @@ npm i react-native-reanimated
 
 </TabItem>
 </Tabs>
-
 
 ## API Reference
 
@@ -161,10 +163,60 @@ It inherits all the properties of React Native's [View](https://reactnative.dev/
 Contains all Text related layout style props and actions.
 It inherits all the properties of React Native's [Text](https://reactnative.dev/docs/text) component.
 
+<>
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHeaderCell>Prop</TableHeaderCell>
+        <TableHeaderCell>Type</TableHeaderCell>
+        <TableHeaderCell>Default</TableHeaderCell>
+        <TableHeaderCell>Description</TableHeaderCell>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableCell>
+          <InlineCode>size</InlineCode>
+        </TableCell>
+        <TableCell>
+          2xs | xs | sm | md | lg | xl | 2xl | 3xl | 4xl | 5xl | 6xl
+        </TableCell>
+        <TableCell>md</TableCell>
+        <TableCell>Sets the font size of the toast title.</TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>
+</>
+
 #### ToastDescription
 
 Contains all Text related layout style props and actions.
 It inherits all the properties of React Native's [Text](https://reactnative.dev/docs/text) component.
+
+<>
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHeaderCell>Prop</TableHeaderCell>
+        <TableHeaderCell>Type</TableHeaderCell>
+        <TableHeaderCell>Default</TableHeaderCell>
+        <TableHeaderCell>Description</TableHeaderCell>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableCell>
+          <InlineCode>size</InlineCode>
+        </TableCell>
+        <TableCell>
+          2xs | xs | sm | md | lg | xl | 2xl | 3xl | 4xl | 5xl | 6xl
+        </TableCell>
+        <TableCell>md</TableCell>
+        <TableCell>Sets the font size of the toast description.</TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>
+</>
 
 ### Accessibility
 

--- a/src/components/ui/tooltip/docs/index.mdx
+++ b/src/components/ui/tooltip/docs/index.mdx
@@ -266,6 +266,31 @@ It inherits all the properties of React Native's [View](https://reactnative.dev/
 
 Contains all text related layout style props and actions. It inherits all the properties of React Native's Text component.
 
+<>
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHeaderCell>Prop</TableHeaderCell>
+        <TableHeaderCell>Type</TableHeaderCell>
+        <TableHeaderCell>Default</TableHeaderCell>
+        <TableHeaderCell>Description</TableHeaderCell>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableCell>
+          <InlineCode>size</InlineCode>
+        </TableCell>
+        <TableCell>
+          2xs | xs | sm | md | lg | xl | 2xl | 3xl | 4xl | 5xl | 6xl
+        </TableCell>
+        <TableCell>-</TableCell>
+        <TableCell>Sets the font size of the tooltip text.</TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>
+</>
+
 #### TooltipContent
 
 Contains all backdrop related layout style props and actions. It inherits all the properties of React Native's [View](https://reactnative.dev/docs/view) component.


### PR DESCRIPTION
… support

- Remove stale size/variant/action props from 8 component docs
- Remove stale size props from menu and form-control examples
- Add missing size/variant docs for radio, tooltip, textarea, toast
- Fix heading default size (md -> lg)
- Add size prop (sm/md/lg) to Avatar with React context propagation