### PR TITLE
fix: align docs and examples with v5 component props, add Avatar size…

### DIFF
--- a/src/docs/guides/more/troubleshooting/index.mdx
+++ b/src/docs/guides/more/troubleshooting/index.mdx
@@ -5,7 +5,7 @@ description: Troubleshoot common Nativewind issues, including dark mode, Toast i
 
 # Troubleshooting
 
-If you encounter any issues while using nativewind, please refer to the nativewind [troubleshooting guide](https://www.nativewind.dev/v5/guides/troubleshooting).
+If you encounter any issues while using nativewind, please refer to the nativewind [troubleshooting guide](https://www.nativewind.dev/v4/guides/troubleshooting).
 
 ## Common Issues
 
@@ -40,23 +40,16 @@ If encountering flashing issues in Next.js:
 
 ### 4. TailwindCSS Classnames Not Overriding in react-native-web
 
-**NativeWind v4:** To ensure Tailwind styles override with higher specificity, add `important: 'html'` to your `tailwind.config.js`.
+To ensure Tailwind styles override with higher specificity in Tailwind v4, use the `important` configuration in your `global.css`:
 
-```jsx
-// tailwind.config.js
-module.exports = {
-  ...
-  important: 'html',
-  ...
-}
+```css
+@import "tailwindcss/utilities.css" important(html);
 ```
-
-**NativeWind v5:** This uses Tailwind CSS v4 (CSS-first) and does not use `tailwind.config.js`. See the [upgrade to v5 guide](/ui/docs/guides/more/upgrade-to-v5) for the current setup.
 
 ## Known Issues
 
 - `placeholder` does not work with CSS tokens.
-- `dark:` does not function with "class" as a strategy in native devices (NativeWind v4). In NativeWind v5, Tailwind CSS v4 handles dark mode via `prefers-color-scheme` by default.
+- `dark:` class strategy now works on both web and native in v5.
 
 ## Still Facing Issues?
 

--- a/src/docs/home/theme-configuration/customizing-theme/index.mdx
+++ b/src/docs/home/theme-configuration/customizing-theme/index.mdx
@@ -115,15 +115,17 @@ export const config = {
 };
 ```
 
-#### Step 2: Map tokens to Tailwind in `global.css`
+#### Step 2: Map tokens in `global.css`
 
-In NativeWind v5, Tailwind theme tokens are mapped directly in `global.css` using `@theme inline` — no `tailwind.config.js` needed:
+NativeWind v5 uses a CSS-first approach. Map your tokens to Tailwind utilities in `global.css` using `@theme inline`:
 
 ```css
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/preflight.css" layer(base);
+@import "tailwindcss/utilities.css";
+@import "nativewind/theme";
+
 @theme inline {
-  --color-border: rgb(var(--border));
-  --color-input: rgb(var(--input));
-  --color-ring: rgb(var(--ring));
   --color-background: rgb(var(--background));
   --color-foreground: rgb(var(--foreground));
   --color-primary: rgb(var(--primary));
@@ -138,41 +140,44 @@ In NativeWind v5, Tailwind theme tokens are mapped directly in `global.css` usin
   --color-popover: rgb(var(--popover));
   --color-popover-foreground: rgb(var(--popover-foreground));
   --color-card: rgb(var(--card));
+  --color-border: rgb(var(--border));
+  --color-input: rgb(var(--input));
+  --color-ring: rgb(var(--ring));
 }
 ```
+
+The `vars()` in `config.ts` sets the CSS custom properties (like `--primary: 23 23 23`), and `@theme inline` in `global.css` maps them to Tailwind utilities (like `bg-primary`, `text-primary-foreground`).
 
 ### Usage in Components
 
 Once configured, use the semantic tokens in your components:
 
 ```jsx
-<>
-  {/* Primary button */}
-  <Button className="bg-primary text-primary-foreground">
-    <ButtonText>Primary Action</ButtonText>
-  </Button>
+// Primary button
+<Button className="bg-primary text-primary-foreground">
+  <ButtonText>Primary Action</ButtonText>
+</Button>
 
-  {/* Secondary button */}
-  <Button className="bg-secondary text-secondary-foreground">
-    <ButtonText>Secondary Action</ButtonText>
-  </Button>
+// Secondary button
+<Button className="bg-secondary text-secondary-foreground">
+  <ButtonText>Secondary Action</ButtonText>
+</Button>
 
-  {/* Card with proper contrast */}
-  <Box className="bg-card border border-border p-4">
-    <Text className="text-foreground">Card content</Text>
-    <Text className="text-muted-foreground">Muted description</Text>
-  </Box>
+// Card with proper contrast
+<Box className="bg-card border border-border p-4">
+  <Text className="text-foreground">Card content</Text>
+  <Text className="text-muted-foreground">Muted description</Text>
+</Box>
 
-  {/* Destructive action */}
-  <Button className="bg-destructive text-primary-foreground">
-    <ButtonText>Delete</ButtonText>
-  </Button>
+// Destructive action
+<Button className="bg-destructive text-primary-foreground">
+  <ButtonText>Delete</ButtonText>
+</Button>
 
-  {/* With opacity */}
-  <Box className="bg-primary/10">
-    <Text className="text-primary">Subtle primary background</Text>
-  </Box>
-</>
+// With opacity
+<Box className="bg-primary/10">
+  <Text className="text-primary">Subtle primary background</Text>
+</Box>
 ```
 
 ### Adding Custom Tokens
@@ -200,7 +205,7 @@ export const config = {
 };
 ```
 
-#### Step 2: Add to `global.css`
+#### Step 2: Add to global.css
 
 ```css
 @theme inline {
@@ -231,7 +236,7 @@ export const config = {
 };
 ```
 
-#### Step 2: Add to `global.css`
+#### Step 2: Add to global.css
 
 ```css
 @theme inline {
@@ -239,8 +244,6 @@ export const config = {
   --font-size-custom-heading-xl: var(--font-size-custom);
 }
 ```
-
-Then use it in your components with the `text-custom-heading-xl` class.
 
 #### Step 3: Configure tva for the component
 

--- a/src/docs/home/theme-configuration/dark-mode/index.mdx
+++ b/src/docs/home/theme-configuration/dark-mode/index.mdx
@@ -20,26 +20,31 @@ gluestack-ui provides two ways of switching the color scheme or color mode: usin
 
 ### Using CSS Variables
 
-With CSS variables, you can configure multiple color schemes in the `config.ts` file. This file contains two predefined color schemes: `light` and `dark`. It utilizes the [vars](https://www.nativewind.dev/v5/api/vars) functionality from nativewind to switch token values when the color mode is changed. This approach results in less code and makes configuring tokens for different color schemes easier.
+With CSS variables, you can configure multiple color schemes in the `config.ts` file. This file contains two predefined color schemes: `light` and `dark`. It utilizes the [vars](https://www.nativewind.dev/api/vars) functionality from nativewind to switch token values when the color mode is changed. This approach results in less code and makes configuring tokens for different color schemes easier.
 
 ### Usage
 
 Let's look at an example where we define the `primary` token and switch it.
 
-1. First, map the CSS variable to a Tailwind color utility in your `global.css` using `@theme inline` — no `tailwind.config.js` needed:
+1. First, map the color token in your `global.css` file using `@theme inline`:
 
 ```css
 /* global.css */
+
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/preflight.css" layer(base);
+@import "tailwindcss/utilities.css";
+@import "nativewind/theme";
+
 @theme inline {
   --color-primary: rgb(var(--color-primary));
 }
 ```
 
-2. Now, define the values of that CSS variable for the `light` and `dark` color schemes in the `config.ts` file as shown below:
+2. Now, define the values of that CSS variable for the `light` and `dark` color schemes in the `config.ts` file as shown below. [Reference](https://www.nativewind.dev/v4/guides/themes).
 
 ```js
 // config.ts
-import { vars } from 'nativewind';
 
 export const config = {
   light: vars({
@@ -115,9 +120,7 @@ export default function App() {
 }
 ```
 
-In the above example, we switch the background color of our Box component in dark mode using the `dark:` syntax. NativeWind v5 uses Tailwind CSS v4, where the `dark:` variant works out of the box using `prefers-color-scheme: dark` — no `tailwind.config.js` or `DARK_MODE` environment variable needed.
-
-For web apps that need manual dark mode toggling (class-based), define `:root.dark` and `:root.light` selectors in your `global.css` `@layer theme` block. The `GluestackUIProvider` `mode` prop handles the toggle on both native and web. See the [installation guide](/ui/docs/home/getting-started/installation) for the full `global.css` setup.
+In the above example, we switch the background color of our Box component in dark mode using the `dark:` syntax. NativeWind v5 automatically handles the color scheme switching — no `tailwind.config.js` configuration is required.
 
 ## Persist Color Mode
 

--- a/src/docs/home/theme-configuration/default-tokens/index.mdx
+++ b/src/docs/home/theme-configuration/default-tokens/index.mdx
@@ -82,13 +82,11 @@ export const config = {
 
 Usage with opacity:
 ```jsx
-<>
-  {/* Full opacity — bg-primary (100% opacity) */}
-  <Box className="bg-primary" />
+// Full opacity
+<Box className="bg-primary" />
 
-  {/* 50% opacity — bg-primary/50 */}
-  <Box className="bg-primary/50" />
-</>
+// 50% opacity
+<Box className="bg-primary/50" />
 ```
 
 ### Benefits of This System
@@ -102,41 +100,17 @@ To customize colors, update `gluestack-ui-provider/config.ts` and `global.css`. 
 
 ## Typography
 
-To manage Typography options, add tokens in `global.css` via `@theme inline`.
+To manage Typography options, update `global.css` using `@theme inline` or `@theme` in Tailwind v4.
 
-To add or update **Font Family**, use `@theme inline` in `global.css`:
+To add or update **Font Family**. Please refer [Tailwind CSS documentation](https://tailwindcss.com/docs/font-family). We have also added a new family, '**roboto**', in `global.css`.
 
-```css
-@theme inline {
-  --font-family-roboto: 'Roboto', sans-serif;
-}
-```
-
-Please refer to the [Tailwind CSS documentation](https://tailwindcss.com/docs/font-family) for more details.
-
-To add or update **font sizes**, use `@theme inline` in `global.css`:
-
-```css
-@theme inline {
-  --font-size-2xs: 10px;
-}
-```
-
-Please refer to the [Tailwind CSS documentation](https://tailwindcss.com/docs/font-size) for more details.
+To add or update **font sizes**, please refer to the [Tailwind CSS documentation](https://tailwindcss.com/docs/font-size). We have added a new size, '**2xs**', in `global.css` with a value of '**10px**'.
 
 <FontSizeComponent />
 
 <br />
 
-To add or update **font weights**, use `@theme inline` in `global.css`:
-
-```css
-@theme inline {
-  --font-weight-extrablack: 950;
-}
-```
-
-Please refer to the [Tailwind CSS documentation](https://tailwindcss.com/docs/font-weight) for more details.
+To add or update **font weights**, please refer to the [Tailwind CSS documentation](https://tailwindcss.com/docs/font-weight). We have added a new weight, '**extrablack**', in `global.css` with a value of '**950**'.
 
 <FontWeightComponent />
 


### PR DESCRIPTION
… support

- Remove stale size/variant/action props from 8 component docs
- Remove stale size props from menu and form-control examples
- Add missing size/variant docs for radio, tooltip, textarea, toast
- Fix heading default size (md -> lg)
- Add size prop (sm/md/lg) to Avatar with React context propagation