### PR TITLE
fix: explicitly close Gorhom BottomSheet in handleClose

### DIFF
--- a/src/components/ui/bottomsheet/index.tsx
+++ b/src/components/ui/bottomsheet/index.tsx
@@ -110,10 +110,11 @@ export const BottomSheet = forwardRef<BottomSheetRef, IBottomSheetRootProps>(
       [defaultSnapIndex, onOpen]
     );
 
-    const handleClose = useCallback(() => {
-      Keyboard.dismiss();
-      setCurrentIndex(-1);
-    }, []);
+    const handleClose = useCallback(() => {                                                                                              
+      Keyboard.dismiss();                                                                                                                
+      setCurrentIndex(-1);                                                                                                               
+      bottomSheetRef.current?.close();                                                                        
+    }, []);     
 
     const handleSheetChanges = useCallback(
       (index: number) => {

--- a/src/components/ui/bottomsheet/index.tsx
+++ b/src/components/ui/bottomsheet/index.tsx
@@ -110,11 +110,11 @@ export const BottomSheet = forwardRef<BottomSheetRef, IBottomSheetRootProps>(
       [defaultSnapIndex, onOpen]
     );
 
-    const handleClose = useCallback(() => {                                                                                              
-      Keyboard.dismiss();                                                                                                                
-      setCurrentIndex(-1);                                                                                                               
-      bottomSheetRef.current?.close();                                                                        
-    }, []);     
+const handleClose = useCallback(() => {
+  Keyboard.dismiss();
+  setCurrentIndex(-1);
+  bottomSheetRef.current?.close();
+}, []);
 
     const handleSheetChanges = useCallback(
       (index: number) => {


### PR DESCRIPTION
When calling sheetRef.current?.close() imperatively, the bottom sheet fails to physically close. handleClose only updates the local currentIndex to -1 but misses explicitly calling Gorhom's close() method. This explicitly triggers the animation.