### PR TITLE
fix: reset color scheme override when using system mode

### DIFF
--- a/src/components/ui/gluestack-ui-provider/index.tsx
+++ b/src/components/ui/gluestack-ui-provider/index.tsx
@@ -15,7 +15,9 @@ export function GluestackUIProvider({
   style?: ViewProps['style'];
 }) {
   useEffect(() => {
-    Appearance.setColorScheme(mode as ColorSchemeName);
+    Appearance.setColorScheme(
+      mode === "system" ? "unspecified" : (mode as ColorSchemeName),
+    );
   }, [mode]);
 
   return (


### PR DESCRIPTION
## Description

`GluestackUIProvider` currently passes the `mode` value directly to `Appearance.setColorScheme()`.

This causes an issue when `mode="system"`:

```ts
Appearance.setColorScheme(mode);
```

`"system"` is a Gluestack provider mode, but it should not be passed to React Native as an application-level color-scheme override. As a result, `useColorScheme()` can return `"system"` instead of the device's actual `"light"` or `"dark"` scheme.

### Fix

When `mode` is `"system"`, explicitly clear the application-level color-scheme override so React Native follows the system setting.

```ts
useEffect(() => {
  Appearance.setColorScheme(
    mode === "system" ? "unspecified" : (mode as ColorSchemeName),
  );
}, [mode]);
```

This also correctly clears a previously configured `"light"` or `"dark"` override when switching back to `"system"`.

### Reproduction

1. Set the device to dark mode.
2. Start the app with `GluestackUIProvider mode="system"`.
3. Read `useColorScheme()` from React Native.
4. The provider can cause `"system"` to be returned instead of `"dark"`.

### Expected behavior

`mode="system"` should follow the device appearance, so `useColorScheme()` should resolve to `"light"` or `"dark"` based on the current system setting.