### PR TITLE
fix (#3460): add option to disable native select on web

### DIFF
--- a/src/components/ui/select/index.tsx
+++ b/src/components/ui/select/index.tsx
@@ -114,6 +114,10 @@ const UISelect = createSelect(
     FlatList: ActionsheetFlatList,
     SectionList: ActionsheetSectionList,
     SectionHeaderText: ActionsheetSectionHeaderText,
+  },
+  //THIS THIRD ARGUMENT TO DISABLE NATIVE SELECT ON WEB
+  {
+    useRNSelect: false,
   }
 );
 
@@ -123,13 +127,14 @@ type ISelectProps = VariantProps<typeof selectStyle> &
 const Select = React.forwardRef<
   React.ComponentRef<typeof UISelect>,
   ISelectProps
->(function Select({ className, ...props }, ref) {
+>(function Select({ className, useRNSelect = false, ...props }, ref) {
   return (
     <UISelect
       className={selectStyle({
         class: className,
       })}
       ref={ref}
+      useRNSelect={useRNSelect}
       {...props}
     />
   );


### PR DESCRIPTION
Fixes #3460

## Fix: Use Actionsheet for Select on Web by Default

### Description

This PR fixes an issue where the `Select` component rendered the native HTML `<select>` element on web instead of using the custom `Actionsheet` portal.

### Changes

* Set `useRNSelect: false` in the `createSelect()` configuration.
* Default `useRNSelect` to `false` in the `Select` component props wrapper.
* This makes the custom `Actionsheet` dropdown the default behavior on web.
* Keeps the existing option to explicitly enable `useRNSelect` when needed.

### Expected Behavior

The `Select` component now opens the styled `Actionsheet` dropdown on web by default, providing a consistent experience with the design system and native platforms.

### Testing

* Verified the `Select` component on web.
* Confirmed that clicking the trigger opens the custom `Actionsheet` instead of the native browser dropdown.
* Confirmed that `useRNSelect` can still be explicitly enabled when required.

### Sanity check:

* [x] Component renders correctly in Kitchen Sink app
* [x] Documentation displays properly on Website app
* [x] Component works in starter templates
* [x] TypeScript types are properly defined
* [x] Accessibility features are implemented
* [x] Examples cover common use cases
* [x] Props are well documented
* [x] Cross-platform compatibility (web and native)
* [ ] Performance tested on lower-end devices
